### PR TITLE
#247 added MDC field of configured party number. Party number MDC fie…

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/IntegrasjonspunktConfig.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/IntegrasjonspunktConfig.java
@@ -3,10 +3,17 @@ package no.difi.meldingsutveksling.config;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRequiredPropertyException;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.noarkexchange.NoarkClientSettings;
-import org.apache.commons.configuration.*;
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.SystemConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
@@ -51,8 +58,14 @@ public class IntegrasjonspunktConfig {
     static final String KEY_PRIVATEKEYPASSWORD = "privatekeypassword";
     public static final String KEY_ORGANISATION_NUMBER = "orgnumber";
     public static final String NOARKSYSTEM_TYPE = "noarksystem.type";
+    public static final String PARTY_NUMBER = "party_number";
 
     private final CompositeConfiguration config;
+
+    @PostConstruct
+    public void addMDCFields() {
+        MDC.put(PARTY_NUMBER, getOrganisationNumber());
+    }
 
     private IntegrasjonspunktConfig() throws MeldingsUtvekslingRequiredPropertyException {
 

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrasjonspunktImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrasjonspunktImpl.java
@@ -1,14 +1,21 @@
 package no.difi.meldingsutveksling.noarkexchange;
 
 import com.thoughtworks.xstream.XStream;
+import no.difi.meldingsutveksling.config.IntegrasjonspunktConfig;
+import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.ProcessState;
 import no.difi.meldingsutveksling.eventlog.Event;
 import no.difi.meldingsutveksling.eventlog.EventLog;
 import no.difi.meldingsutveksling.noarkexchange.putmessage.PutMessageContext;
 import no.difi.meldingsutveksling.noarkexchange.putmessage.PutMessageStrategy;
 import no.difi.meldingsutveksling.noarkexchange.putmessage.PutMessageStrategyFactory;
-import no.difi.meldingsutveksling.noarkexchange.schema.*;
+import no.difi.meldingsutveksling.noarkexchange.schema.GetCanReceiveMessageRequestType;
+import no.difi.meldingsutveksling.noarkexchange.schema.GetCanReceiveMessageResponseType;
+import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageRequestType;
+import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageResponseType;
+import no.difi.meldingsutveksling.noarkexchange.schema.SOAPport;
 import no.difi.meldingsutveksling.services.AdresseregisterService;
+import org.jboss.logging.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +54,9 @@ public class IntegrasjonspunktImpl implements SOAPport {
     @Autowired
     private NoarkClient mshClient;
 
+    @Autowired
+    IntegrasjonspunktConfig configuration;
+
     @Override
     public GetCanReceiveMessageResponseType getCanReceiveMessage(@WebParam(name = "GetCanReceiveMessageRequest", targetNamespace = "http://www.arkivverket.no/Noark/Exchange/types", partName = "getCanReceiveMessageRequest") GetCanReceiveMessageRequestType getCanReceiveMessageRequest) {
 
@@ -78,6 +88,14 @@ public class IntegrasjonspunktImpl implements SOAPport {
 
     @Override
     public PutMessageResponseType putMessage(PutMessageRequestType req) {
+        PutMessageRequestAdapter message = new PutMessageRequestAdapter(req);
+        if (!message.hasSenderPartyNumber() && !configuration.hasOrganisationNumber()) {
+            throw new MeldingsUtvekslingRuntimeException();
+        }
+        final String partyNumber = message.hasSenderPartyNumber() ? message.getSenderPartynumber() : configuration.getOrganisationNumber();
+
+        MDC.put(IntegrasjonspunktConfig.PARTY_NUMBER, partyNumber);
+
         if(hasAdresseregisterCertificate(req.getEnvelope().getReceiver().getOrgnr())) {
             PutMessageContext context = new PutMessageContext(eventLog, messageSender);
             PutMessageStrategyFactory putMessageStrategyFactory = PutMessageStrategyFactory.newInstance(context);

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/MessageSender.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/MessageSender.java
@@ -5,7 +5,6 @@ import com.thoughtworks.xstream.XStream;
 import no.difi.meldingsutveksling.IntegrasjonspunktNokkel;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktConfig;
 import no.difi.meldingsutveksling.domain.Avsender;
-import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.Mottaker;
 import no.difi.meldingsutveksling.domain.Noekkelpar;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
@@ -132,9 +131,6 @@ public class MessageSender {
         if(!message.hasRecieverPartyNumber()) {
             log.error(ErrorStatus.MISSING_RECIPIENT.toString());
             context.addError(ErrorStatus.MISSING_RECIPIENT);
-        }
-        if (!message.hasSenderPartyNumber() && !configuration.hasOrganisationNumber()) {
-            throw new MeldingsUtvekslingRuntimeException();
         }
 
         JournalpostId p = JournalpostId.fromPutMessage(message);


### PR DESCRIPTION
…ld will be overwritten if message request contains sender organization number. This is automatically included as a field to logback and can be used to identify log messages originating from a given organization number (party_number).
