### PR TITLE
closes #323

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/ConfigDebugLogger.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/ConfigDebugLogger.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 /**
  * the onApplicationEvent is executed during startup of the application
  *
- * @Author Glenn Bech
  */
 @Component
 public class ConfigDebugLogger implements ApplicationListener<ContextRefreshedEvent> {
@@ -24,7 +23,6 @@ public class ConfigDebugLogger implements ApplicationListener<ContextRefreshedEv
     public void onApplicationEvent(final ContextRefreshedEvent event) {
         final ConfigMeta metadata = config.getMetadata();
         metadata.logInfo();
-        System.out.println(metadata.toString());
     }
 
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/ConfigMeta.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/ConfigMeta.java
@@ -1,10 +1,17 @@
 package no.difi.meldingsutveksling.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
+import net.logstash.logback.marker.LogstashMarker;
+import net.logstash.logback.marker.Markers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.logging.Logger;
+import java.util.Map;
 
 /**
  * Class that contains denormalised metadata about the current configuration. Used for logging and
@@ -14,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class ConfigMeta {
 
-    private static final Logger logger = Logger.getLogger(ConfigMeta.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(ConfigMeta.class.getName());
 
     private List<ConfigGroup> configGroups;
 
@@ -34,11 +41,18 @@ public class ConfigMeta {
     }
 
     public void logInfo() {
-        for (ConfigGroup g : configGroups) {
-            for (ConfigElement e : g.elements) {
-                logger.info("configGroup " + g.name + ", key `" + e.key + "`,value `" + e.value + "`");
+        logger.info(createLogMarkers(), "Startup configuration");
+    }
+
+    private LogstashMarker createLogMarkers() {
+        Map<String, String> fields = new HashMap<>();
+
+        for(ConfigGroup g: configGroups) {
+            for(ConfigElement e: g.getElements()) {
+                fields.put(e.key, e.value);
             }
         }
+        return Markers.appendEntries(fields);
     }
 
     public static class Builder {

--- a/integrasjonspunkt/src/main/resources/logback.xml
+++ b/integrasjonspunkt/src/main/resources/logback.xml
@@ -50,6 +50,20 @@
             </encoder>
         </appender>
 
+    <appender name="configMetaConsole" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%msg: %marker%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="no.difi.meldingsutveksling.config.ConfigMeta" additivity="false">
+        <appender-ref ref="stash"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="configMetaConsole"/>
+    </logger>
+
+
         <root level="INFO">
             <appender-ref ref="consoleAppender" />
             <appender-ref ref="FILE"/>


### PR DESCRIPTION
#323 Changed the way startup parameters are logged:
- No longer printed to console directly but using Logback
- Configuration parameters added as fields in logstash
- Configuration parameters logged using SLF4J instead of Java API logger
- Console printing is not as pretty as it was
- Could use create markers in a better way (code quality)
