### PR TITLE
Fix/#405 avoid duplicate leveringskvitteringer

### DIFF
--- a/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnClient.java
+++ b/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnClient.java
@@ -4,7 +4,7 @@ import no.altinn.schemas.services.intermediary.receipt._2009._10.*;
 import no.altinn.schemas.services.intermediary.shipment._2009._10.ReferenceType;
 import no.altinn.services.intermediary.receipt._2009._10.IReceiptExternalBasicGetReceiptBasicAltinnFaultFaultFaultMessage;
 import no.altinn.services.intermediary.receipt._2009._10.ReceiptExternalBasicSF;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 
 import javax.xml.bind.JAXBContext;
@@ -42,10 +42,10 @@ public class AltinnClient {
 
     private void printIt(AltinnPackage altinnPackage) {
         try {
-            JAXBContext ctx = JAXBContext.newInstance(Document.class);
+            JAXBContext ctx = JAXBContext.newInstance(EduDocument.class);
             Marshaller marshaller = ctx.createMarshaller();
             no.difi.meldingsutveksling.domain.sbdh.ObjectFactory objectFactory = new no.difi.meldingsutveksling.domain.sbdh.ObjectFactory();
-            marshaller.marshal(objectFactory.createStandardBusinessDocument(altinnPackage.getDocument()), System.out);
+            marshaller.marshal(objectFactory.createStandardBusinessDocument(altinnPackage.getEduDocument()), System.out);
         } catch (JAXBException e) {
             e.printStackTrace();
         }

--- a/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnPackage.java
+++ b/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnPackage.java
@@ -3,7 +3,7 @@ package no.difi.meldingsutveksling;
 import no.altinn.schema.services.serviceengine.broker._2015._06.BrokerServiceManifest;
 import no.altinn.schema.services.serviceengine.broker._2015._06.BrokerServiceRecipientList;
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 import no.difi.meldingsutveksling.shipping.sftp.BrokerServiceManifestBuilder;
@@ -35,20 +35,20 @@ public class AltinnPackage {
     private static JAXBContext ctx;
     private final BrokerServiceManifest manifest;
     private final BrokerServiceRecipientList recipient;
-    private final Document document;
+    private final EduDocument eduDocument;
 
     static {
         try {
-            ctx = JAXBContext.newInstance(BrokerServiceManifest.class, BrokerServiceRecipientList.class, Document.class, Payload.class, Kvittering.class);
+            ctx = JAXBContext.newInstance(BrokerServiceManifest.class, BrokerServiceRecipientList.class, EduDocument.class, Payload.class, Kvittering.class);
         } catch (JAXBException e) {
             throw new RuntimeException("Could not create JAXBContext", e);
         }
     }
 
-    private AltinnPackage(BrokerServiceManifest manifest, BrokerServiceRecipientList recipient, Document document) {
+    private AltinnPackage(BrokerServiceManifest manifest, BrokerServiceRecipientList recipient, EduDocument eduDocument) {
         this.manifest = manifest;
         this.recipient = recipient;
-        this.document = document;
+        this.eduDocument = eduDocument;
     }
 
     public static AltinnPackage from(UploadRequest document) {
@@ -84,7 +84,7 @@ public class AltinnPackage {
 
         zipOutputStream.putNextEntry(new ZipEntry("content.xml"));
         no.difi.meldingsutveksling.domain.sbdh.ObjectFactory objectFactory = new no.difi.meldingsutveksling.domain.sbdh.ObjectFactory();
-        marshallObject(objectFactory.createStandardBusinessDocument(document), zipOutputStream);
+        marshallObject(objectFactory.createStandardBusinessDocument(eduDocument), zipOutputStream);
         zipOutputStream.closeEntry();
 
         zipOutputStream.finish();
@@ -106,7 +106,7 @@ public class AltinnPackage {
         ArchiveEntry zipEntry;
         BrokerServiceManifest manifest = null;
         BrokerServiceRecipientList recipientList = null;
-        Document document = null;
+        EduDocument eduDocument = null;
 
         while ((zipEntry = zipInputStream.getNextEntry()) != null) {
             if (zipEntry.getName().equals("manifest.xml")) {
@@ -115,10 +115,10 @@ public class AltinnPackage {
                 recipientList = (BrokerServiceRecipientList) unmarshaller.unmarshal(inputStreamProxy);
             } else if (zipEntry.getName().equals("content.xml")) {
                 Source source = new StreamSource(inputStreamProxy);
-                document = unmarshaller.unmarshal(source, Document.class).getValue();
+                eduDocument = unmarshaller.unmarshal(source, EduDocument.class).getValue();
             }
         }
-        return new AltinnPackage(manifest, recipientList, document);
+        return new AltinnPackage(manifest, recipientList, eduDocument);
     }
 
     private void marshallObject(Object object, OutputStream outputStream) {
@@ -132,7 +132,7 @@ public class AltinnPackage {
 
     }
 
-    public Document getDocument() {
-        return document;
+    public EduDocument getEduDocument() {
+        return eduDocument;
     }
 }

--- a/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnWsClient.java
+++ b/altinn-client/src/main/java/no/difi/meldingsutveksling/AltinnWsClient.java
@@ -4,7 +4,7 @@ import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
 import no.difi.meldingsutveksling.altinn.mock.brokerbasic.*;
 import no.difi.meldingsutveksling.altinn.mock.brokerstreamed.*;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.logging.Audit;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 import no.difi.meldingsutveksling.shipping.ws.AltinnReasonFactory;
@@ -109,7 +109,7 @@ public class AltinnWsClient {
     }
 
 
-    public Document download(DownloadRequest request) {
+    public EduDocument download(DownloadRequest request) {
         BrokerServiceExternalBasicStreamedSF brokerServiceExternalBasicStreamedSF;
         brokerServiceExternalBasicStreamedSF = new BrokerServiceExternalBasicStreamedSF(configuration.getStreamingServiceUrl());
         IBrokerServiceExternalBasicStreamed streamingService = brokerServiceExternalBasicStreamedSF.getBasicHttpBindingIBrokerServiceExternalBasicStreamed(new MTOMFeature(true));
@@ -122,7 +122,7 @@ public class AltinnWsClient {
         try {
             message = streamingService.downloadFileStreamedBasic(configuration.getUsername(), configuration.getPassword(), request.getFileReference(), request.getReciever());
             AltinnPackage altinnPackage = AltinnPackage.from(new ByteArrayInputStream(message));
-            return altinnPackage.getDocument();
+            return altinnPackage.getEduDocument();
 
         } catch (IBrokerServiceExternalBasicStreamedDownloadFileStreamedBasicAltinnFaultFaultFaultMessage e) {
             throw new AltinnWsException(CANNOT_DOWNLOAD_FILE, AltinnReasonFactory.from(e), e);

--- a/altinn-client/src/main/java/no/difi/meldingsutveksling/shipping/UploadRequest.java
+++ b/altinn-client/src/main/java/no/difi/meldingsutveksling/shipping/UploadRequest.java
@@ -1,11 +1,11 @@
 package no.difi.meldingsutveksling.shipping;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 
 public interface UploadRequest {
-    public String getSender();
-    public String getReceiver();
-    public String getSenderReference();
+    String getSender();
+    String getReceiver();
+    String getSenderReference();
 
-    Document getPayload();
+    EduDocument getPayload();
 }

--- a/altinn-client/src/test/java/no/difi/meldingsutveksling/MockRequest.java
+++ b/altinn-client/src/test/java/no/difi/meldingsutveksling/MockRequest.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 
 public class MockRequest implements UploadRequest {
@@ -27,7 +27,7 @@ public class MockRequest implements UploadRequest {
         }
 
         @Override
-        public Document getPayload() {
-        return new Document();
+        public EduDocument getPayload() {
+        return new EduDocument();
     }
 }

--- a/altinn-client/src/test/java/no/difi/meldingsutveksling/TryAltinnClient.java
+++ b/altinn-client/src/test/java/no/difi/meldingsutveksling/TryAltinnClient.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 
 public class TryAltinnClient {
@@ -23,8 +23,8 @@ public class TryAltinnClient {
         }
 
         @Override
-        public Document getPayload() {
-            return new Document();
+        public EduDocument getPayload() {
+            return new EduDocument();
         }
 
     }

--- a/dokumentpakking/src/main/java/no/difi/meldingsutveksling/dokumentpakking/service/CreateSBD.java
+++ b/dokumentpakking/src/main/java/no/difi/meldingsutveksling/dokumentpakking/service/CreateSBD.java
@@ -3,7 +3,7 @@ package no.difi.meldingsutveksling.dokumentpakking.service;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
 import no.difi.meldingsutveksling.domain.sbdh.BusinessScope;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.DocumentIdentification;
 import no.difi.meldingsutveksling.domain.sbdh.Partner;
 import no.difi.meldingsutveksling.domain.sbdh.PartnerIdentification;
@@ -26,8 +26,8 @@ public class CreateSBD {
 	public static final String HEADER_VERSION = "1.0";
 	public static final String TYPE_VERSION = "1.0";
 
-    public Document createSBD(Organisasjonsnummer avsender, Organisasjonsnummer mottaker, Object payload, String conversationId, String type, String journalPostId) {
-		Document doc = new Document();
+    public EduDocument createSBD(Organisasjonsnummer avsender, Organisasjonsnummer mottaker, Object payload, String conversationId, String type, String journalPostId) {
+		EduDocument doc = new EduDocument();
 		doc.setStandardBusinessDocumentHeader(createHeader(avsender, mottaker, conversationId, type, journalPostId));
 		doc.setAny(payload);
 		return doc;

--- a/dokumentpakking/src/main/java/no/difi/meldingsutveksling/dokumentpakking/service/ScopeFactory.java
+++ b/dokumentpakking/src/main/java/no/difi/meldingsutveksling/dokumentpakking/service/ScopeFactory.java
@@ -1,23 +1,22 @@
 package no.difi.meldingsutveksling.dokumentpakking.service;
 
 import no.difi.meldingsutveksling.domain.sbdh.Scope;
+import no.difi.meldingsutveksling.domain.sbdh.ScopeType;
 
 public class ScopeFactory {
 
-    public static final String TYPE_JOURNALPOST_ID = "JournalpostId";
-    public static final String TYPE_CONVERSATIONID = "ConversationId";
     public static final String DEFAULT_IDENTIFIER = "urn:no:difi:meldingsutveksling:1.0";
 
     public static Scope fromJournalPostId(String journalPostId) {
         Scope scope = createDefaultScope();
-        scope.setType(TYPE_JOURNALPOST_ID);
+        scope.setType(ScopeType.JournalpostId.name());
         scope.setInstanceIdentifier(journalPostId);
         return scope;
     }
 
-    public static final Scope fromConversationId(String conversationId) {
+    public static Scope fromConversationId(String conversationId) {
         Scope scope = createDefaultScope();
-        scope.setType(TYPE_CONVERSATIONID);
+        scope.setType(ScopeType.ConversationId.name());
         scope.setInstanceIdentifier(conversationId);
         return scope;
     }

--- a/domain/src/main/java/no/difi/meldingsutveksling/StandardBusinessDocumentConverter.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/StandardBusinessDocumentConverter.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.ObjectFactory;
 
 import javax.xml.bind.JAXBContext;
@@ -16,46 +16,46 @@ public class StandardBusinessDocumentConverter {
 
     static {
         try {
-            ctx = JAXBContext.newInstance(Document.class);
+            ctx = JAXBContext.newInstance(EduDocument.class);
         } catch (JAXBException e) {
             throw new RuntimeException("Could not initialize " + StandardBusinessDocumentConverter.class, e);
         }
     }
-    public byte[] marshallToBytes(Document document) {
+    public byte[] marshallToBytes(EduDocument eduDocument) {
         Marshaller marshaller;
         try {
             marshaller = ctx.createMarshaller();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not create marshaller for " + Document.class, e);
+            throw new RuntimeException("Could not create marshaller for " + EduDocument.class, e);
         }
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ObjectFactory objectFactory = new ObjectFactory();
 
         try {
-            marshaller.marshal(objectFactory.createStandardBusinessDocument(document), output);
+            marshaller.marshal(objectFactory.createStandardBusinessDocument(eduDocument), output);
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not marshall " + document, e);
+            throw new RuntimeException("Could not marshall " + eduDocument, e);
         }
         return output.toByteArray();
     }
 
-    public Document unmarshallFrom(byte[] bytes) {
+    public EduDocument unmarshallFrom(byte[] bytes) {
         Unmarshaller unmarshaller;
 
         try {
             unmarshaller = ctx.createUnmarshaller();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not create Unmarshaller for " + Document.class, e);
+            throw new RuntimeException("Could not create Unmarshaller for " + EduDocument.class, e);
         }
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
         StreamSource streamSource = new StreamSource(inputStream);
 
-        Document sbd;
+        EduDocument sbd;
         try {
-            sbd = unmarshaller.unmarshal(streamSource, Document.class).getValue();
+            sbd = unmarshaller.unmarshal(streamSource, EduDocument.class).getValue();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not unmarshall to " + Document.class, e);
+            throw new RuntimeException("Could not unmarshall to " + EduDocument.class, e);
         }
 
         return sbd;

--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/MessageInfo.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/MessageInfo.java
@@ -1,0 +1,37 @@
+package no.difi.meldingsutveksling.domain;
+
+/**
+ * Contains information needed to identify a message: who the sender and the receiver is, the original journalpost
+ * and the transaction (conversation).
+ *
+ * To be used with logging and receipts to reduce parameters in methods and dependency to the standard business document.
+ */
+public class MessageInfo {
+    String receiverOrgNumber;
+    String senderOrgNumber;
+    String journalPostId;
+    String conversationId;
+
+    public MessageInfo(String receiverOrgNumber, String senderOrgNumber, String journalPostId, String conversationId) {
+        this.receiverOrgNumber = receiverOrgNumber;
+        this.senderOrgNumber = senderOrgNumber;
+        this.journalPostId = journalPostId;
+        this.conversationId = conversationId;
+    }
+
+    public String getReceiverOrgNumber() {
+        return receiverOrgNumber;
+    }
+
+    public String getSenderOrgNumber() {
+        return senderOrgNumber;
+    }
+
+    public String getJournalPostId() {
+        return journalPostId;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+}

--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/Document.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/Document.java
@@ -8,6 +8,7 @@
 
 package no.difi.meldingsutveksling.domain.sbdh;
 
+import no.difi.meldingsutveksling.domain.MessageInfo;
 import org.w3c.dom.Element;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -15,6 +16,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
 
 /**
@@ -97,6 +99,36 @@ public class Document {
      */
     public void setAny(Object value) {
         this.any = value;
+    }
+
+    public MessageInfo getMessageInfo() {
+        return new MessageInfo(getReceiverOrgNumber(), getSenderOrgNumber(), getJournalPostId(), getConversationId());
+    }
+
+    public String getSenderOrgNumber() {
+        return getStandardBusinessDocumentHeader().getSender().get(0).getIdentifier().getValue().split(":")[1];
+    }
+
+    public String getReceiverOrgNumber() {
+        return getStandardBusinessDocumentHeader().getReceiver().get(0).getIdentifier().getValue().split(":")[1];
+    }
+
+    public final String getJournalPostId() {
+        return findScope(ScopeType.JournalpostId).getInstanceIdentifier();
+    }
+
+    public String getConversationId() {
+        return findScope(ScopeType.ConversationId).getInstanceIdentifier();
+    }
+
+    private Scope findScope(ScopeType scopeType) {
+        final List<Scope> scopes = getStandardBusinessDocumentHeader().getBusinessScope().getScope();
+        for (Scope scope : scopes) {
+            if (scopeType.name().equals(scope.getType())) {
+                return scope;
+            }
+        }
+        return new Scope();
     }
 
 }

--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/EduDocument.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/EduDocument.java
@@ -44,7 +44,7 @@ import java.util.List;
     "standardBusinessDocumentHeader",
     "any"
 })
-public class Document {
+public class EduDocument {
 
     @XmlElement(name = "StandardBusinessDocumentHeader")
     protected StandardBusinessDocumentHeader standardBusinessDocumentHeader;

--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/ObjectFactory.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/ObjectFactory.java
@@ -61,11 +61,11 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link Document }
+     * Create an instance of {@link EduDocument }
      * 
      */
-    public Document createStandardBusinessDocument() {
-        return new Document();
+    public EduDocument createStandardBusinessDocument() {
+        return new EduDocument();
     }
 
     /**
@@ -154,7 +154,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", name = "CorrelationInformation", substitutionHeadNamespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", substitutionHeadName = "ScopeInformation")
     public JAXBElement<CorrelationInformation> createCorrelationInformation(CorrelationInformation value) {
-        return new JAXBElement<CorrelationInformation>(_CorrelationInformation_QNAME, CorrelationInformation.class, null, value);
+        return new JAXBElement<>(_CorrelationInformation_QNAME, CorrelationInformation.class, null, value);
     }
 
     /**
@@ -163,7 +163,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", name = "BusinessService", substitutionHeadNamespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", substitutionHeadName = "ScopeInformation")
     public JAXBElement<BusinessService> createBusinessService(BusinessService value) {
-        return new JAXBElement<BusinessService>(_BusinessService_QNAME, BusinessService.class, null, value);
+        return new JAXBElement<>(_BusinessService_QNAME, BusinessService.class, null, value);
     }
 
     /**
@@ -172,7 +172,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", name = "ScopeInformation")
     public JAXBElement<Object> createScopeInformation(Object value) {
-        return new JAXBElement<Object>(_ScopeInformation_QNAME, Object.class, null, value);
+        return new JAXBElement<>(_ScopeInformation_QNAME, Object.class, null, value);
     }
 
     /**
@@ -181,16 +181,16 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", name = "StandardBusinessDocumentHeader")
     public JAXBElement<StandardBusinessDocumentHeader> createStandardBusinessDocumentHeader(StandardBusinessDocumentHeader value) {
-        return new JAXBElement<StandardBusinessDocumentHeader>(_StandardBusinessDocumentHeader_QNAME, StandardBusinessDocumentHeader.class, null, value);
+        return new JAXBElement<>(_StandardBusinessDocumentHeader_QNAME, StandardBusinessDocumentHeader.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Document }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link EduDocument }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader", name = "StandardBusinessDocument")
-    public JAXBElement<Document> createStandardBusinessDocument(Document value) {
-        return new JAXBElement<Document>(_StandardBusinessDocument_QNAME, Document.class, null, value);
+    public JAXBElement<EduDocument> createStandardBusinessDocument(EduDocument value) {
+        return new JAXBElement<>(_StandardBusinessDocument_QNAME, EduDocument.class, null, value);
     }
 
 }

--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/ScopeType.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/ScopeType.java
@@ -1,0 +1,6 @@
+package no.difi.meldingsutveksling.domain.sbdh;
+
+public enum ScopeType {
+    JournalpostId,
+    ConversationId
+}

--- a/domain/src/test/java/no/difi/meldingsutveksling/StandardBusinessDocumentConverterTest.java
+++ b/domain/src/test/java/no/difi/meldingsutveksling/StandardBusinessDocumentConverterTest.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.ObjectFactory;
 import org.junit.Test;
 
@@ -10,7 +10,7 @@ public class StandardBusinessDocumentConverterTest {
     public void testMarshallToBytes() throws Exception {
         StandardBusinessDocumentConverter converter = new StandardBusinessDocumentConverter();
 
-        Document sbd = new Document();
+        EduDocument sbd = new EduDocument();
 
         sbd.setAny(new ObjectFactory().createScopeInformation("Hello world!"));
         converter.marshallToBytes(sbd);

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/logging/MessageMarkerFactory.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/logging/MessageMarkerFactory.java
@@ -4,6 +4,7 @@ import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
 import no.difi.meldingsutveksling.FileReference;
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
+import no.difi.meldingsutveksling.domain.MessageInfo;
 import no.difi.meldingsutveksling.noarkexchange.PutMessageRequestWrapper;
 import no.difi.meldingsutveksling.noarkexchange.StandardBusinessDocumentWrapper;
 import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageResponseType;
@@ -112,6 +113,13 @@ public class MessageMarkerFactory {
         final LogstashMarker receiverMarker = receiverMarker(documentWrapper.getReceiverOrgNumber());
         final LogstashMarker senderMarker = senderMarker(documentWrapper.getSenderOrgNumber());
         return documentIdMarker.and(journalPostIdMarker).and(conversationIdMarker).and(senderMarker).and(receiverMarker);
+    }
+
+    public static LogstashMarker markerFrom(MessageInfo messageInfo) {
+        final LogstashMarker jpMarker = journalPostIdMarker(messageInfo.getJournalPostId());
+        final LogstashMarker sMarker = senderMarker(messageInfo.getSenderOrgNumber());
+        final LogstashMarker rMarker = receiverMarker(messageInfo.getReceiverOrgNumber());
+        return jpMarker.and(sMarker).and(rMarker);
     }
 
 

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
@@ -102,9 +102,8 @@ public class IntegrajonspunktReceiveImpl implements SOAReceivePort {
             return new CorrelationInformation();
         }
 
+        // TODO: remove? or move to send leveringskvittering i internal queue?
         logEvent(document, ProcessState.SBD_RECIEVED);
-        sendReceiptDelivered(document);
-        Audit.info("Delivery receipt sent", markerFrom(document));
 
         Payload payload = document.getPayload();
         byte[] decryptedAsicPackage = decrypt(payload);
@@ -140,20 +139,16 @@ public class IntegrajonspunktReceiveImpl implements SOAReceivePort {
     }
 
     private void sendReceiptDelivered(StandardBusinessDocumentWrapper inputDocument) {
-        Document doc = KvitteringFactory.createLeveringsKvittering(inputDocument.getSenderOrgNumber(),
-                inputDocument.getReceiverOrgNumber(), inputDocument.getJournalPostId(),
-                inputDocument.getConversationId(), keyInfo.getKeyPair());
-        sendReceipt(inputDocument, doc);
+        Document doc = KvitteringFactory.createLeveringsKvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
+        sendReceipt(doc);
     }
 
     private void sendReceiptOpen(StandardBusinessDocumentWrapper inputDocument) {
-        Document doc = KvitteringFactory.createAapningskvittering(inputDocument.getSenderOrgNumber(),
-                inputDocument.getReceiverOrgNumber(), inputDocument.getJournalPostId(),
-                inputDocument.getConversationId(), keyInfo.getKeyPair());
-        sendReceipt(inputDocument, doc);
+        Document doc = KvitteringFactory.createAapningskvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
+        sendReceipt(doc);
     }
 
-    private void sendReceipt(StandardBusinessDocumentWrapper input, Document receipt) {
+    private void sendReceipt(Document receipt) {
         Transport t = transportFactory.createTransport(receipt);
         t.send(config.getConfiguration(), receipt);
     }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
@@ -5,7 +5,7 @@ import no.difi.meldingsutveksling.config.IntegrasjonspunktConfiguration;
 import no.difi.meldingsutveksling.dokumentpakking.service.CmsUtil;
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
 import no.difi.meldingsutveksling.domain.ProcessState;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.eventlog.Event;
 import no.difi.meldingsutveksling.eventlog.EventLog;
 import no.difi.meldingsutveksling.kvittering.KvitteringFactory;
@@ -129,7 +129,7 @@ public class IntegrajonspunktReceiveImpl implements SOAReceivePort {
         PutMessageResponseType response = localNoark.sendEduMelding(putMessageRequestType);
         AppReceiptType result = response.getResult();
         if (result.getType().equals(OK_TYPE)) {
-            Audit.info("Document successfully delivered to NOARK system. Sending receipt back to sender...", markerFrom(response));
+            Audit.info("EduDocument successfully delivered to NOARK system. Sending receipt back to sender...", markerFrom(response));
             sendReceiptOpen(inputDocument);
             logEvent(inputDocument, ProcessState.BEST_EDU_SENT);
         } else {
@@ -139,16 +139,16 @@ public class IntegrajonspunktReceiveImpl implements SOAReceivePort {
     }
 
     private void sendReceiptDelivered(StandardBusinessDocumentWrapper inputDocument) {
-        Document doc = KvitteringFactory.createLeveringsKvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
+        EduDocument doc = KvitteringFactory.createLeveringsKvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
         sendReceipt(doc);
     }
 
     private void sendReceiptOpen(StandardBusinessDocumentWrapper inputDocument) {
-        Document doc = KvitteringFactory.createAapningskvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
+        EduDocument doc = KvitteringFactory.createAapningskvittering(inputDocument.getMessageInfo(), keyInfo.getKeyPair());
         sendReceipt(doc);
     }
 
-    private void sendReceipt(Document receipt) {
+    private void sendReceipt(EduDocument receipt) {
         Transport t = transportFactory.createTransport(receipt);
         t.send(config.getConfiguration(), receipt);
     }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/MessageSender.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/MessageSender.java
@@ -7,8 +7,8 @@ import no.difi.meldingsutveksling.domain.Avsender;
 import no.difi.meldingsutveksling.domain.Mottaker;
 import no.difi.meldingsutveksling.domain.Noekkelpar;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.logging.Audit;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
 import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageRequestType;
 import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageResponseType;
 import no.difi.meldingsutveksling.services.AdresseregisterVirksert;
@@ -90,25 +90,25 @@ public class MessageSender {
 
         Audit.info("Sender and receivers signatures are validated", markerFrom(message));
 
-        no.difi.meldingsutveksling.domain.sbdh.Document sbd;
+        EduDocument edu;
         try {
-            sbd = standardBusinessDocumentFactory.create(messageRequest, messageContext.getAvsender(), messageContext.getMottaker());
+            edu = standardBusinessDocumentFactory.create(messageRequest, messageContext.getAvsender(), messageContext.getMottaker());
         } catch (MessageException e) {
-            Audit.error("Unable to create Standard Business Document. Message is not delievered", markerFrom(message));
+            Audit.error("Unable to create Edu Document. Message is not delievered", markerFrom(message));
             log.error(markerFrom(message), e.getStatusMessage().getTechnicalMessage(), e);
             return createErrorResponse(e);
         }
-        Audit.info("Successfully created Standard Business Document. Sending message...", markerFrom(message));
+        Audit.info("Successfully created Edu Document. Sending message...", markerFrom(message));
 
-        Transport t = transportFactory.createTransport(sbd);
-        t.send(configuration.getConfiguration(), sbd);
+        Transport t = transportFactory.createTransport(edu);
+        t.send(configuration.getConfiguration(), edu);
 
         Audit.info("Message delivered", markerFrom(message));
 
         return createOkResponse();
     }
 
-    public void sendMessage(Document doc) {
+    public void sendMessage(EduDocument doc) {
         Transport t = transportFactory.createTransport(doc);
         t.send(configuration.getConfiguration(), doc);
     }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentFactory.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentFactory.java
@@ -1,7 +1,6 @@
 package no.difi.meldingsutveksling.noarkexchange;
 
 import net.logstash.logback.marker.LogstashMarker;
-import net.logstash.logback.marker.Markers;
 import no.difi.meldingsutveksling.IntegrasjonspunktNokkel;
 import no.difi.meldingsutveksling.StandardBusinessDocumentConverter;
 import no.difi.meldingsutveksling.dokumentpakking.domain.Archive;
@@ -13,7 +12,7 @@ import no.difi.meldingsutveksling.domain.Avsender;
 import no.difi.meldingsutveksling.domain.BestEduMessage;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.Mottaker;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
 import no.difi.meldingsutveksling.logging.Audit;
 import no.difi.meldingsutveksling.noarkexchange.schema.ObjectFactory;
@@ -51,7 +50,7 @@ public class StandardBusinessDocumentFactory {
     static {
         try {
             jaxbContext = JAXBContext.newInstance(StandardBusinessDocument.class, Payload.class, Kvittering.class);
-            jaxbContextdomain = JAXBContext.newInstance(Document.class, Payload.class, Kvittering.class);
+            jaxbContextdomain = JAXBContext.newInstance(EduDocument.class, Payload.class, Kvittering.class);
         } catch (JAXBException e) {
             throw new MeldingsUtvekslingRuntimeException("Could not initialize " + StandardBusinessDocumentConverter.class, e);
         }
@@ -64,11 +63,11 @@ public class StandardBusinessDocumentFactory {
         this.integrasjonspunktNokkel = integrasjonspunktNokkel;
     }
 
-    public Document create(PutMessageRequestType sender, Avsender avsender, Mottaker mottaker) throws MessageException {
+    public EduDocument create(PutMessageRequestType sender, Avsender avsender, Mottaker mottaker) throws MessageException {
         return create(sender, UUID.randomUUID().toString(), avsender, mottaker);
     }
 
-    public Document create(PutMessageRequestType shipment, String conversationId, Avsender avsender, Mottaker mottaker) throws MessageException {
+    public EduDocument create(PutMessageRequestType shipment, String conversationId, Avsender avsender, Mottaker mottaker) throws MessageException {
         final byte[] marshalledShipment = marshall(shipment);
 
         BestEduMessage bestEduMessage = new BestEduMessage(marshalledShipment);
@@ -107,15 +106,15 @@ public class StandardBusinessDocumentFactory {
         return os.toByteArray();
     }
 
-    public static Document create(StandardBusinessDocument fromDocument) {
+    public static EduDocument create(StandardBusinessDocument fromDocument) {
         ModelMapper mapper = new ModelMapper();
-        return mapper.map(fromDocument, Document.class);
+        return mapper.map(fromDocument, EduDocument.class);
     }
 
-    public static StandardBusinessDocument create(Document fromDocument) {
+    public static StandardBusinessDocument create(EduDocument fromDocument) {
         try {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
-            JAXBElement<Document> d = new no.difi.meldingsutveksling.domain.sbdh.ObjectFactory().createStandardBusinessDocument(fromDocument);
+            JAXBElement<EduDocument> d = new no.difi.meldingsutveksling.domain.sbdh.ObjectFactory().createStandardBusinessDocument(fromDocument);
 
             jaxbContextdomain.createMarshaller().marshal(d, os);
             byte[] tmp = os.toByteArray();

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentWrapper.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentWrapper.java
@@ -3,6 +3,8 @@ package no.difi.meldingsutveksling.noarkexchange;
 import no.difi.meldingsutveksling.dokumentpakking.service.ScopeFactory;
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
+import no.difi.meldingsutveksling.domain.MessageInfo;
+import no.difi.meldingsutveksling.domain.sbdh.ScopeType;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocumentHeader;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.Scope;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument;
@@ -41,11 +43,15 @@ public class StandardBusinessDocumentWrapper {
     }
 
     public String getConversationId() {
-        return findScope(ScopeFactory.TYPE_CONVERSATIONID).getInstanceIdentifier();
+        return findScope(ScopeType.ConversationId.name()).getInstanceIdentifier();
     }
 
     public final String getJournalPostId() {
-        return findScope(ScopeFactory.TYPE_JOURNALPOST_ID).getInstanceIdentifier();
+        return findScope(ScopeType.JournalpostId.name()).getInstanceIdentifier();
+    }
+
+    public MessageInfo getMessageInfo() {
+        return new MessageInfo(getReceiverOrgNumber(), getSenderOrgNumber(), getJournalPostId(), getConversationId());
     }
 
     private Scope findScope(String scopeType) {

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/altinn/MessagePolling.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/altinn/MessagePolling.java
@@ -7,7 +7,7 @@ import no.difi.meldingsutveksling.DownloadRequest;
 import no.difi.meldingsutveksling.FileReference;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktConfiguration;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.elma.ELMALookup;
 import no.difi.meldingsutveksling.logging.Audit;
 import no.difi.meldingsutveksling.noarkexchange.receive.InternalQueue;
@@ -67,9 +67,9 @@ public class MessagePolling {
 
         for (FileReference reference : fileReferences) {
             Audit.info("Downloading message", markerFrom(reference));
-            Document document = client.download(new DownloadRequest(reference.getValue(), config.getOrganisationNumber()));
+            EduDocument eduDocument = client.download(new DownloadRequest(reference.getValue(), config.getOrganisationNumber()));
 
-            internalQueue.enqueueNoark(document);
+            internalQueue.enqueueNoark(eduDocument);
         }
     }
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/altinn/MessagePolling.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/altinn/MessagePolling.java
@@ -62,12 +62,12 @@ public class MessagePolling {
         List<FileReference> fileReferences = client.availableFiles(config.getOrganisationNumber());
 
         if(!fileReferences.isEmpty()) {
-            Audit.info("Found new messages! Proceeding with download...");
+            Audit.info("New messages");
         }
 
         for (FileReference reference : fileReferences) {
-            Audit.info("Downloading message", markerFrom(reference));
             EduDocument eduDocument = client.download(new DownloadRequest(reference.getValue(), config.getOrganisationNumber()));
+            Audit.info("Message downloaded", markerFrom(reference));
 
             internalQueue.enqueueNoark(eduDocument);
         }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/receive/DocumentConverter.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/receive/DocumentConverter.java
@@ -1,7 +1,7 @@
 package no.difi.meldingsutveksling.noarkexchange.receive;
 
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.ObjectFactory;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
 
@@ -18,48 +18,48 @@ public class DocumentConverter {
 
     static {
         try {
-            ctx = JAXBContext.newInstance(Document.class, Payload.class, Kvittering.class);
+            ctx = JAXBContext.newInstance(EduDocument.class, Payload.class, Kvittering.class);
         } catch (JAXBException e) {
             throw new RuntimeException("Could not initialize " + DocumentConverter.class, e);
         }
     }
-    public byte[] marshallToBytes(Document document) {
+    public byte[] marshallToBytes(EduDocument eduDocument) {
         Marshaller marshaller;
         try {
             marshaller = ctx.createMarshaller();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not create marshaller for " + Document.class, e);
+            throw new RuntimeException("Could not create marshaller for " + EduDocument.class, e);
         }
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ObjectFactory objectFactory = new ObjectFactory();
 
         try {
-            marshaller.marshal(objectFactory.createStandardBusinessDocument(document), output);
+            marshaller.marshal(objectFactory.createStandardBusinessDocument(eduDocument), output);
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not marshall " + document, e);
+            throw new RuntimeException("Could not marshall " + eduDocument, e);
         }
         return output.toByteArray();
     }
 
-    public Document unmarshallFrom(byte[] bytes) {
+    public EduDocument unmarshallFrom(byte[] bytes) {
         Unmarshaller unmarshaller;
 
         try {
             unmarshaller = ctx.createUnmarshaller();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not create Unmarshaller for " + Document.class, e);
+            throw new RuntimeException("Could not create Unmarshaller for " + EduDocument.class, e);
         }
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
         StreamSource streamSource = new StreamSource(inputStream);
 
-        Document sbd;
+        EduDocument edu;
         try {
-            sbd = unmarshaller.unmarshal(streamSource, Document.class).getValue();
+            edu = unmarshaller.unmarshal(streamSource, EduDocument.class).getValue();
         } catch (JAXBException e) {
-            throw new RuntimeException("Could not unmarshall to " + Document.class, e);
+            throw new RuntimeException("Could not unmarshall to " + EduDocument.class, e);
         }
 
-        return sbd;
+        return edu;
     }
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/receive/PutMessageRequestConverter.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/receive/PutMessageRequestConverter.java
@@ -1,9 +1,5 @@
 package no.difi.meldingsutveksling.noarkexchange.receive;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
-import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
-import no.difi.meldingsutveksling.noarkexchange.schema.AppReceiptType;
-import no.difi.meldingsutveksling.noarkexchange.schema.ObjectFactory;
 import no.difi.meldingsutveksling.noarkexchange.schema.PutMessageRequestType;
 
 import javax.xml.bind.*;

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentFactoryTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentFactoryTest.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling.noarkexchange;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import org.junit.Test;
 
 import javax.xml.bind.JAXBContext;
@@ -21,7 +21,7 @@ public class StandardBusinessDocumentFactoryTest {
         JAXBContext ctx = JAXBContext.newInstance(no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument.class);
         Unmarshaller unmarshaller = ctx.createUnmarshaller();
         fromDocument = unmarshaller.unmarshal(new StreamSource(getClass().getClassLoader().getResourceAsStream("sample_dbd_document.xml")), no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument.class);
-        Document result = StandardBusinessDocumentFactory.create(fromDocument.getValue());
+        EduDocument result = StandardBusinessDocumentFactory.create(fromDocument.getValue());
         assertNotNull(result);
     }
 

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentWrapperTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/StandardBusinessDocumentWrapperTest.java
@@ -1,6 +1,7 @@
 package no.difi.meldingsutveksling.noarkexchange;
 
 import no.difi.meldingsutveksling.dokumentpakking.service.ScopeFactory;
+import no.difi.meldingsutveksling.domain.sbdh.ScopeType;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.BusinessScope;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.DocumentIdentification;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.Scope;
@@ -16,8 +17,8 @@ import static org.junit.Assert.assertEquals;
 public class StandardBusinessDocumentWrapperTest {
 
     public static final String DEFAULT_IDENTIFIER = "urn:no:difi:sdp:1.0";
-    public static final String TYPE_CONVERSATION_ID = ScopeFactory.TYPE_CONVERSATIONID;
-    public static final String TYPE_JOURNAL_POST_ID = ScopeFactory.TYPE_JOURNALPOST_ID;
+    public static final String TYPE_CONVERSATION_ID = ScopeType.ConversationId.name();
+    public static final String TYPE_JOURNAL_POST_ID = ScopeType.JournalpostId.name();
 
     public static final String JOURNALPOST_ID = "1234";
     public static final String CONVERSATION_ID = "5555";

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/putmessage/PutMessageSteps.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/putmessage/PutMessageSteps.java
@@ -10,7 +10,7 @@ import no.difi.meldingsutveksling.IntegrasjonspunktNokkel;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktConfiguration;
 import no.difi.meldingsutveksling.domain.Mottaker;
 import no.difi.meldingsutveksling.domain.sbdh.BusinessScope;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.Scope;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocumentHeader;
 import no.difi.meldingsutveksling.eventlog.Event;
@@ -80,32 +80,32 @@ public class PutMessageSteps {
         when(integrasjonspunktNokkel.getSignatureHelper()).thenReturn(mock(SignatureHelper.class));
         StandardBusinessDocumentFactory documentFactory = mock(StandardBusinessDocumentFactory.class);
 
-        Document document = createStandardBusinessDocument();
+        EduDocument eduDocument = createStandardBusinessDocument();
 
-        when(documentFactory.create(any(PutMessageRequestType.class), any(no.difi.meldingsutveksling.domain.Avsender.class), any(Mottaker.class))).thenReturn(document);
+        when(documentFactory.create(any(PutMessageRequestType.class), any(no.difi.meldingsutveksling.domain.Avsender.class), any(Mottaker.class))).thenReturn(eduDocument);
         messageSender.setStandardBusinessDocumentFactory(documentFactory);
         messageSender.setKeyInfo(integrasjonspunktNokkel);
         messageSender.setConfiguration(mock(IntegrasjonspunktConfiguration.class));
 
         TransportFactory transportFactory = mock(TransportFactory.class);
         transport = mock(Transport.class);
-        when(transportFactory.createTransport(any(Document.class))).thenReturn(transport);
+        when(transportFactory.createTransport(any(EduDocument.class))).thenReturn(transport);
         messageSender.setTransportFactory(transportFactory);
 
         integrasjonspunkt.setMessageSender(messageSender);
         integrasjonspunkt.setAdresseRegister(adresseregister);
   }
 
-    private Document createStandardBusinessDocument() {
-        Document document = new Document();
+    private EduDocument createStandardBusinessDocument() {
+        EduDocument eduDocument = new EduDocument();
         StandardBusinessDocumentHeader header = new StandardBusinessDocumentHeader();
         BusinessScope scope = new BusinessScope();
         ArrayList<Scope> scopes = new ArrayList<>();
         scopes.add(new Scope());
         scope.setScope(scopes);
         header.setBusinessScope(scope);
-        document.setStandardBusinessDocumentHeader(header);
-        return document;
+        eduDocument.setStandardBusinessDocumentHeader(header);
+        return eduDocument;
     }
 
 
@@ -138,7 +138,7 @@ public class PutMessageSteps {
 
     @Then("^kvitteringen sendes ikke videre til transport$")
     public void kvitteringen_sendes_ikke_videre()  {
-        verify(transport, never()).send(any(Environment.class), any(Document.class));
+        verify(transport, never()).send(any(Environment.class), any(EduDocument.class));
     }
 
     @Given("^en velformet melding fra (.+)$")
@@ -158,7 +158,7 @@ public class PutMessageSteps {
 
     @Then("^skal melding bli videresendt$")
     public void skal_melding_bli_videresendt() throws Throwable {
-        verify(transport).send(any(Environment.class), any(Document.class));
+        verify(transport).send(any(Environment.class), any(EduDocument.class));
     }
 
     @When("^integrasjonspunktet mottar meldingen$")

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/receive/InternalQueueMain.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/noarkexchange/receive/InternalQueueMain.java
@@ -1,7 +1,7 @@
 package no.difi.meldingsutveksling.noarkexchange.receive;
 
 import no.difi.meldingsutveksling.config.JmsConfiguration;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocumentHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -21,11 +21,11 @@ public class InternalQueueMain extends SpringBootServletInitializer {
     InternalQueue queue;
 
     public void testPut() {
-        Document document = new Document();
+        EduDocument eduDocument = new EduDocument();
         StandardBusinessDocumentHeader header = new StandardBusinessDocumentHeader();
         header.setHeaderVersion("some header version");
-        document.setStandardBusinessDocumentHeader(header);
-        queue.enqueueNoark(document);
+        eduDocument.setStandardBusinessDocumentHeader(header);
+        queue.enqueueNoark(eduDocument);
     }
 
     public static void main(String... args) {

--- a/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/DocumentToDocumentConverter.java
+++ b/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/DocumentToDocumentConverter.java
@@ -2,6 +2,7 @@ package no.difi.meldingsutveksling.kvittering;
 
 
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.ObjectFactory;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
 import org.w3c.dom.Document;
@@ -30,7 +31,7 @@ class DocumentToDocumentConverter {
 
     static {
         try {
-            jaxBContext = JAXBContext.newInstance(no.difi.meldingsutveksling.domain.sbdh.Document.class, Kvittering.class);
+            jaxBContext = JAXBContext.newInstance(EduDocument.class, Kvittering.class);
         } catch (JAXBException e) {
             throw new MeldingsUtvekslingRuntimeException(e.getMessage(), e);
         }
@@ -41,9 +42,8 @@ class DocumentToDocumentConverter {
      * from a  from an org.w3c.document
      *
      * @param domDocument the source document
-     * @throws JAXBException
      */
-    public static no.difi.meldingsutveksling.domain.sbdh.Document toDomainDocument(Document domDocument) {
+    public static EduDocument toDomainDocument(Document domDocument) {
         TransformerFactory tf = TransformerFactory.newInstance();
         Transformer t;
         try {
@@ -51,19 +51,18 @@ class DocumentToDocumentConverter {
             DOMSource source = new DOMSource(domDocument);
             JAXBResult result = new JAXBResult(jaxBContext);
             t.transform(source, result);
-            return ((JAXBElement<no.difi.meldingsutveksling.domain.sbdh.Document>) result.getResult()).getValue();
+            return ((JAXBElement<EduDocument>) result.getResult()).getValue();
         } catch (TransformerException | JAXBException e) {
             throw new MeldingsUtvekslingRuntimeException(e);
         }
     }
 
     /**
-     * Marshell the contained document to an org.w3c.Document representation
+     * Marshall the contained document to an org.w3c.Document representation
      *
-     * @return
-     * @throws JAXBException
+     * @return org.w3c.Document
      */
-    public static Document toXMLDocument(no.difi.meldingsutveksling.domain.sbdh.Document jaxbDocument ) {
+    public static Document toXMLDocument(EduDocument jaxbDocument ) {
         try {
             Marshaller marshaller = jaxBContext.createMarshaller();
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -75,7 +74,7 @@ class DocumentToDocumentConverter {
             } catch (ParserConfigurationException e) {
                 throw new MeldingsUtvekslingRuntimeException(e);
             }
-            JAXBElement<no.difi.meldingsutveksling.domain.sbdh.Document> jbe = new ObjectFactory().createStandardBusinessDocument(jaxbDocument);
+            JAXBElement<EduDocument> jbe = new ObjectFactory().createStandardBusinessDocument(jaxbDocument);
             marshaller.marshal(jbe, domDocument);
             return domDocument;
         } catch (JAXBException e) {

--- a/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
+++ b/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
@@ -64,8 +64,9 @@ public class KvitteringFactory {
 
         EduDocument unsignedReceipt = new EduDocument();
         StandardBusinessDocumentHeader header = new StandardBusinessDocumentHeader.Builder()
-                .from(new Organisasjonsnummer(messageInfo.getSenderOrgNumber()))
-                .to(new Organisasjonsnummer(messageInfo.getReceiverOrgNumber()))
+                // sender of the receipt is the receiver of the message
+                .from(new Organisasjonsnummer(messageInfo.getReceiverOrgNumber()))
+                .to(new Organisasjonsnummer(messageInfo.getSenderOrgNumber()))
                 .relatedToConversationId(messageInfo.getConversationId())
                 .relatedToJournalPostId(messageInfo.getJournalPostId())
                 .type(StandardBusinessDocumentHeader.DocumentType.KVITTERING)

--- a/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
+++ b/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
@@ -4,6 +4,7 @@ package no.difi.meldingsutveksling.kvittering;
 import no.difi.meldingsutveksling.StandardBusinessDocumentConverter;
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
+import no.difi.meldingsutveksling.domain.MessageInfo;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
 import no.difi.meldingsutveksling.domain.XMLTimeStamp;
 import no.difi.meldingsutveksling.domain.sbdh.Document;
@@ -43,31 +44,30 @@ public class KvitteringFactory {
     }
 
 
-    public static Document createAapningskvittering(String receiverOrgNumber, String senderOrgNumber,
-                                                    String journalPostId, String conversationId, KeyPair keyPair) {
+    public static Document createAapningskvittering(MessageInfo messageInfo, KeyPair keyPair) {
         Kvittering k = new Kvittering();
         k.setAapning(new Aapning());
         k.setTidspunkt(XMLTimeStamp.createTimeStamp());
-        return signAndWrapDocument(receiverOrgNumber, senderOrgNumber, journalPostId, conversationId, keyPair, k);
+        return signAndWrapDocument(messageInfo, keyPair, k);
     }
 
-    public static Document createLeveringsKvittering(String receiverOrgNumber, String senderOrgNumber,
-                                                     String journalPostId, String conversationId, KeyPair keyPair) {
+    public static Document createLeveringsKvittering(MessageInfo messageInfo, KeyPair keyPair) {
         Kvittering k = new Kvittering();
         k.setLevering(new Levering());
         k.setTidspunkt(XMLTimeStamp.createTimeStamp());
-        return signAndWrapDocument(receiverOrgNumber, senderOrgNumber, journalPostId, conversationId, keyPair, k);
+        return signAndWrapDocument(messageInfo,
+                keyPair,
+                k);
     }
 
-    private static Document signAndWrapDocument(String receiverOrgNumber, String senderOrgNumber, String journalPostId,
-                                                String conversationId, KeyPair keyPair, Kvittering kvittering) {
+    private static Document signAndWrapDocument(MessageInfo messageInfo, KeyPair keyPair, Kvittering kvittering) {
 
         Document unsignedReceipt = new Document();
         StandardBusinessDocumentHeader header = new StandardBusinessDocumentHeader.Builder()
-                .from(new Organisasjonsnummer(senderOrgNumber))
-                .to(new Organisasjonsnummer(receiverOrgNumber))
-                .relatedToConversationId(conversationId)
-                .relatedToJournalPostId(journalPostId)
+                .from(new Organisasjonsnummer(messageInfo.getSenderOrgNumber()))
+                .to(new Organisasjonsnummer(messageInfo.getReceiverOrgNumber()))
+                .relatedToConversationId(messageInfo.getConversationId())
+                .relatedToJournalPostId(messageInfo.getJournalPostId())
                 .type(StandardBusinessDocumentHeader.DocumentType.KVITTERING)
                 .build();
 

--- a/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
+++ b/kvittering/src/main/java/no/difi/meldingsutveksling/kvittering/KvitteringFactory.java
@@ -7,7 +7,7 @@ import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.MessageInfo;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
 import no.difi.meldingsutveksling.domain.XMLTimeStamp;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocumentHeader;
 import no.difi.meldingsutveksling.kvittering.xsd.Aapning;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
@@ -37,21 +37,21 @@ public class KvitteringFactory {
     static {
         try {
             jaxbContext = JAXBContext.newInstance(StandardBusinessDocument.class, Payload.class, Kvittering.class);
-            jaxbContextdomain = JAXBContext.newInstance(Document.class, Payload.class, Kvittering.class);
+            jaxbContextdomain = JAXBContext.newInstance(EduDocument.class, Payload.class, Kvittering.class);
         } catch (JAXBException e) {
             throw new MeldingsUtvekslingRuntimeException("Could not initialize " + StandardBusinessDocumentConverter.class, e);
         }
     }
 
 
-    public static Document createAapningskvittering(MessageInfo messageInfo, KeyPair keyPair) {
+    public static EduDocument createAapningskvittering(MessageInfo messageInfo, KeyPair keyPair) {
         Kvittering k = new Kvittering();
         k.setAapning(new Aapning());
         k.setTidspunkt(XMLTimeStamp.createTimeStamp());
         return signAndWrapDocument(messageInfo, keyPair, k);
     }
 
-    public static Document createLeveringsKvittering(MessageInfo messageInfo, KeyPair keyPair) {
+    public static EduDocument createLeveringsKvittering(MessageInfo messageInfo, KeyPair keyPair) {
         Kvittering k = new Kvittering();
         k.setLevering(new Levering());
         k.setTidspunkt(XMLTimeStamp.createTimeStamp());
@@ -60,9 +60,9 @@ public class KvitteringFactory {
                 k);
     }
 
-    private static Document signAndWrapDocument(MessageInfo messageInfo, KeyPair keyPair, Kvittering kvittering) {
+    private static EduDocument signAndWrapDocument(MessageInfo messageInfo, KeyPair keyPair, Kvittering kvittering) {
 
-        Document unsignedReceipt = new Document();
+        EduDocument unsignedReceipt = new EduDocument();
         StandardBusinessDocumentHeader header = new StandardBusinessDocumentHeader.Builder()
                 .from(new Organisasjonsnummer(messageInfo.getSenderOrgNumber()))
                 .to(new Organisasjonsnummer(messageInfo.getReceiverOrgNumber()))

--- a/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/EduDocumentValidatorTest.java
+++ b/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/EduDocumentValidatorTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Glenn Bech
  */
-public class DocumentValidatorTest {
+public class EduDocumentValidatorTest {
 
     @Test
     public void should_verify_external_document_that_is_valid() throws XMLSignatureException, ParserConfigurationException, SAXException, IOException {
@@ -24,7 +24,7 @@ public class DocumentValidatorTest {
         dbf.setNamespaceAware(true);
         DocumentBuilder builder;
         builder = dbf.newDocumentBuilder();
-        Document doc = builder.parse(DocumentValidatorTest.class.getClassLoader().getResourceAsStream("signed_sbd_kvittering.xml"));
+        Document doc = builder.parse(EduDocumentValidatorTest.class.getClassLoader().getResourceAsStream("signed_sbd_kvittering.xml"));
         assertTrue(DocumentValidator.validate(doc));
     }
 }

--- a/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/StandardBusinessDocumentWrapperTest.java
+++ b/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/StandardBusinessDocumentWrapperTest.java
@@ -1,6 +1,7 @@
 package no.difi.meldingsutveksling.kvittering;
 
 
+import no.difi.meldingsutveksling.domain.MessageInfo;
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
 import no.difi.meldingsutveksling.kvittering.xsd.ObjectFactory;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.Partner;
@@ -35,7 +36,7 @@ public class StandardBusinessDocumentWrapperTest {
         kpg.initialize(512);
         KeyPair kp = kpg.generateKeyPair();
 
-        no.difi.meldingsutveksling.domain.sbdh.Document beforeConversion = KvitteringFactory.createAapningskvittering(RECEIVER, SENDER, "", "", kp);
+        no.difi.meldingsutveksling.domain.sbdh.Document beforeConversion = KvitteringFactory.createAapningskvittering(new MessageInfo(RECEIVER, SENDER, "", ""), kp);
         Document xmlDocVersion = DocumentToDocumentConverter.toXMLDocument(beforeConversion);
         no.difi.meldingsutveksling.domain.sbdh.Document afterConversion = DocumentToDocumentConverter.toDomainDocument(xmlDocVersion);
 

--- a/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/StandardBusinessDocumentWrapperTest.java
+++ b/kvittering/src/test/java/no/difi/meldingsutveksling/kvittering/StandardBusinessDocumentWrapperTest.java
@@ -2,16 +2,10 @@ package no.difi.meldingsutveksling.kvittering;
 
 
 import no.difi.meldingsutveksling.domain.MessageInfo;
-import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
-import no.difi.meldingsutveksling.kvittering.xsd.ObjectFactory;
-import no.difi.meldingsutveksling.noarkexchange.schema.receive.Partner;
-import no.difi.meldingsutveksling.noarkexchange.schema.receive.PartnerIdentification;
-import no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument;
-import no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocumentHeader;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 
 import java.security.KeyPair;
@@ -36,9 +30,9 @@ public class StandardBusinessDocumentWrapperTest {
         kpg.initialize(512);
         KeyPair kp = kpg.generateKeyPair();
 
-        no.difi.meldingsutveksling.domain.sbdh.Document beforeConversion = KvitteringFactory.createAapningskvittering(new MessageInfo(RECEIVER, SENDER, "", ""), kp);
+        EduDocument beforeConversion = KvitteringFactory.createAapningskvittering(new MessageInfo(RECEIVER, SENDER, "", ""), kp);
         Document xmlDocVersion = DocumentToDocumentConverter.toXMLDocument(beforeConversion);
-        no.difi.meldingsutveksling.domain.sbdh.Document afterConversion = DocumentToDocumentConverter.toDomainDocument(xmlDocVersion);
+        EduDocument afterConversion = DocumentToDocumentConverter.toDomainDocument(xmlDocVersion);
 
         assertEquals(beforeConversion.getStandardBusinessDocumentHeader().getSender().get(0).getIdentifier().getValue(),
                 afterConversion.getStandardBusinessDocumentHeader().getSender().get(0).getIdentifier().getValue());

--- a/transport-altinn/src/main/java/no/difi/meldingsutveksling/transport/altinn/AltinnTransport.java
+++ b/transport-altinn/src/main/java/no/difi/meldingsutveksling/transport/altinn/AltinnTransport.java
@@ -4,7 +4,7 @@ import no.difi.meldingsutveksling.AltinnWsClient;
 import no.difi.meldingsutveksling.AltinnWsConfiguration;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
 import no.difi.meldingsutveksling.domain.Organisasjonsnummer;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.elma.ELMALookup;
 import no.difi.meldingsutveksling.shipping.UploadRequest;
 import no.difi.meldingsutveksling.transport.Transport;
@@ -30,10 +30,10 @@ public class AltinnTransport implements Transport {
 
     /**
      * @param environment a configuration object given by the integrasjonspunkt
-     * @param document      An SBD document with a payload consisting of an CMS encrypted ASIC package
+     * @param eduDocument      An eduDocument with a payload consisting of an CMS encrypted ASIC package
      */
     @Override
-    public void send(Environment environment, final Document document) {
+    public void send(Environment environment, final EduDocument eduDocument) {
         Endpoint ep;
         try {
             ep = elmaLookup.lookup(organisationNumber);
@@ -45,13 +45,13 @@ public class AltinnTransport implements Transport {
 
             @Override
             public String getSender() {
-                Organisasjonsnummer orgNumberSender = fromIso6523(document.getStandardBusinessDocumentHeader().getSender().get(0).getIdentifier().getValue());
+                Organisasjonsnummer orgNumberSender = fromIso6523(eduDocument.getStandardBusinessDocumentHeader().getSender().get(0).getIdentifier().getValue());
                 return orgNumberSender.toString();
             }
 
             @Override
             public String getReceiver() {
-                Organisasjonsnummer orgNumberReceiver = fromIso6523(document.getStandardBusinessDocumentHeader().getReceiver().get(0).getIdentifier().getValue());
+                Organisasjonsnummer orgNumberReceiver = fromIso6523(eduDocument.getStandardBusinessDocumentHeader().getReceiver().get(0).getIdentifier().getValue());
                 return orgNumberReceiver.toString();
             }
 
@@ -61,8 +61,8 @@ public class AltinnTransport implements Transport {
             }
 
             @Override
-            public Document getPayload() {
-                return document;
+            public EduDocument getPayload() {
+                return eduDocument;
             }
         };
 

--- a/transport-altinn/src/main/java/no/difi/meldingsutveksling/transport/altinn/AltinnTransportFactory.java
+++ b/transport-altinn/src/main/java/no/difi/meldingsutveksling/transport/altinn/AltinnTransportFactory.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling.transport.altinn;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocumentHeader;
 import no.difi.meldingsutveksling.elma.ELMALookup;
 import no.difi.meldingsutveksling.transport.Transport;
@@ -23,7 +23,7 @@ public class AltinnTransportFactory implements TransportFactory {
     ELMALookup elmaLookup;
 
     @Override
-    public Transport createTransport(Document message) {
+    public Transport createTransport(EduDocument message) {
         StandardBusinessDocumentHeader standardBusinessDocumentHeader = message.getStandardBusinessDocumentHeader();
         final String receiverOrganisationNumber = standardBusinessDocumentHeader.getReceiverOrganisationNumber();
         return new AltinnTransport(receiverOrganisationNumber, elmaLookup);

--- a/transport-file/src/main/java/no/difi/meldingsutveksling/transport/FileTransport.java
+++ b/transport-file/src/main/java/no/difi/meldingsutveksling/transport/FileTransport.java
@@ -2,7 +2,7 @@ package no.difi.meldingsutveksling.transport;
 
 import no.difi.meldingsutveksling.dokumentpakking.xml.Payload;
 import no.difi.meldingsutveksling.domain.MeldingsUtvekslingRuntimeException;
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.domain.sbdh.ObjectFactory;
 
 import no.difi.meldingsutveksling.kvittering.xsd.Kvittering;
@@ -27,19 +27,19 @@ import java.io.FileOutputStream;
 public class FileTransport implements Transport {
 
     @Override
-    public void send(Environment environment, Document document) {
+    public void send(Environment environment, EduDocument eduDocument) {
         String fileName = createFilename();
         ModelMapper mapper = new ModelMapper();
 
         no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument toWrite =
-                mapper.map(document, no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument.class);
+                mapper.map(eduDocument, no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument.class);
 
         File f = new File(fileName);
         try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(Document.class, Payload.class, Kvittering.class);
+            JAXBContext jaxbContext = JAXBContext.newInstance(EduDocument.class, Payload.class, Kvittering.class);
             Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
             jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            jaxbMarshaller.marshal(new ObjectFactory().createStandardBusinessDocument(document), new FileOutputStream(f));
+            jaxbMarshaller.marshal(new ObjectFactory().createStandardBusinessDocument(eduDocument), new FileOutputStream(f));
             JAXBElement<no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument> element =
                     new JAXBElement<>(new QName("ns"),
                             no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument.class, toWrite);

--- a/transport-file/src/test/java/no/difi/meldingsutveksling/transport/FileTransportTest.java
+++ b/transport-file/src/test/java/no/difi/meldingsutveksling/transport/FileTransportTest.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling.transport;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import no.difi.meldingsutveksling.noarkexchange.schema.receive.StandardBusinessDocument;
 import org.modelmapper.ModelMapper;
 
@@ -23,8 +23,8 @@ public class FileTransportTest {
 
         ModelMapper mapper = new ModelMapper();
 
-        Document domainDoc
-                = mapper.map(doc, Document.class);
+        EduDocument domainDoc
+                = mapper.map(doc, EduDocument.class);
 
         t.send(null, domainDoc);
 

--- a/transport/src/main/java/no/difi/meldingsutveksling/transport/Transport.java
+++ b/transport/src/main/java/no/difi/meldingsutveksling/transport/Transport.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling.transport;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 import org.springframework.core.env.Environment;
 
 /**
@@ -15,8 +15,8 @@ import org.springframework.core.env.Environment;
 public interface Transport {
 
     /**
-     * @param document An SBD document with a payload consisting of an CMS encrypted ASIC package
+     * @param eduDocument An eduDocument with a payload consisting of an CMS encrypted ASIC package
      */
-    public void send(Environment environment, Document document);
+    void send(Environment environment, EduDocument eduDocument);
 
 }

--- a/transport/src/main/java/no/difi/meldingsutveksling/transport/TransportFactory.java
+++ b/transport/src/main/java/no/difi/meldingsutveksling/transport/TransportFactory.java
@@ -1,6 +1,6 @@
 package no.difi.meldingsutveksling.transport;
 
-import no.difi.meldingsutveksling.domain.sbdh.Document;
+import no.difi.meldingsutveksling.domain.sbdh.EduDocument;
 
 /**
  * Factory class to configure transport based on a SBD document. Implementations of this can use content in the StandardBusinessDocument
@@ -11,7 +11,7 @@ import no.difi.meldingsutveksling.domain.sbdh.Document;
 
 public interface TransportFactory {
 
-    Transport createTransport(Document message);
+    Transport createTransport(EduDocument message);
 
 }
 


### PR DESCRIPTION
Leveringskvittering is now sent before message is put on queue.

Renamed domainobject: Document to EduDocument