### PR TITLE
Bytter Java-imaget som arves her til det offisielle Java imaget som n…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM 7-jre-alpine
+FROM java:7-jre-alpine
 MAINTAINER DIFI <espen.korra@difi.no>
 
 LABEL package="no.difi"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dervism/dockerjava:jre7
+FROM 7-jre-alpine
 MAINTAINER DIFI <espen.korra@difi.no>
 
 LABEL package="no.difi"


### PR DESCRIPTION
Bytter Java-imaget som arves her til det offisielle Java imaget som nå også bruker Alpine.

Se det offisielle Java-repet her: https://hub.docker.com/_/java/