### PR TITLE
Bytter Java-imaget til det offisielle Java-imaget i DockerHub

### DIFF
--- a/integrasjonspunkt/Dockerfile
+++ b/integrasjonspunkt/Dockerfile
@@ -1,4 +1,4 @@
-FROM dervism/dockerjava:jre7
+FROM java:7-jre-alpine
 MAINTAINER DIFI <espen.korra@difi.no>
 
 LABEL package="no.difi"


### PR DESCRIPTION
Det er ikke lenger nødvendig å bruke imaget som jeg selv laget (den gang var det ikke så mange andre alternativer). Oracle sitt offisielle Java-image på DockerHub bruker nå Alpine og da er det bedre å bruke den.

Jeg har testet at security mappene og JAVA_HOME env variabelen også er tilstede i det offisielle imaget, så endringen bør ikke medføre noen konsekvenser.