### PR TITLE
Remove transport-virksomhet dependency from integrasjonspunkt

### DIFF
--- a/integrasjonspunkt/pom.xml
+++ b/integrasjonspunkt/pom.xml
@@ -407,11 +407,6 @@
         </dependency>
         <dependency>
             <groupId>no.difi.meldingsutveksling</groupId>
-            <artifactId>transport-virksomhet</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>no.difi.meldingsutveksling</groupId>
             <artifactId>post-til-virksomhet</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
Broke build when maven doesn't have local copy.