### PR TITLE
Fix broken master:

### DIFF
--- a/integrasjonspunkt/pom.xml
+++ b/integrasjonspunkt/pom.xml
@@ -232,11 +232,12 @@
 
         <!-- end logging/monitoring -->
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
+        <!-- Spring Boot Devtools causes class loader problems with Metro generated SOAP clients. -->
+        <!--<dependency>-->
+            <!--<groupId>org.springframework.boot</groupId>-->
+            <!--<artifactId>spring-boot-devtools</artifactId>-->
+            <!--<optional>true</optional>-->
+        <!--</dependency>-->
 
         <dependency>
             <groupId>de.codecentric</groupId>

--- a/noarkexchange/pom.xml
+++ b/noarkexchange/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>no.difi.meldingsutveksling</groupId>
-            <artifactId>ws-tools</artifactId>
+            <artifactId>webservice-tools</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         

--- a/post-til-private/pom.xml
+++ b/post-til-private/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>no.difi.meldingsutveksling</groupId>
-            <artifactId>ws-tools</artifactId>
+            <artifactId>webservice-tools</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/webservice-tools/pom.xml
+++ b/webservice-tools/pom.xml
@@ -7,9 +7,11 @@
         <groupId>no.difi.meldingsutveksling</groupId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>ws-tools</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>webservice-tools</artifactId>
+    <version>${project.parent.version}</version>
+
     <dependencies>
         <dependency>
             <groupId>net.logstash.logback</groupId>
@@ -26,12 +28,5 @@
             <artifactId>audit</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>no.difi.meldingsutveksling</groupId>
-            <artifactId>ws-tools</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
     </dependencies>
-
-
 </project>


### PR DESCRIPTION
Spring boot devtools causes classloader problems with Metro clients
Fixed maven errors with project webservice-tools (ws-tools)