### PR TITLE
MOVE-1124: Eksplisitt sjekk om integrasjonspunkt-local.properties finnes

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/IntegrasjonspunktApplication.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/IntegrasjonspunktApplication.java
@@ -3,6 +3,7 @@ package no.difi.meldingsutveksling;
 import com.sun.xml.ws.transport.http.servlet.WSSpringServlet;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktPropertiesValidator;
+import no.difi.meldingsutveksling.spring.IntegrasjonspunktLocalPropertyEnvironmentPostProcessor;
 import no.difi.move.common.config.SpringCloudProtocolResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,7 @@ public class IntegrasjonspunktApplication extends SpringBootServletInitializer {
 
             ConfigurableApplicationContext context = new SpringApplicationBuilder(IntegrasjonspunktApplication.class)
                     .initializers(new SpringCloudProtocolResolver())
+                    .listeners(new IntegrasjonspunktLocalPropertyEnvironmentPostProcessor())
                     .run(args);
             checkNtpSync(context);
 

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/spring/IntegrasjonspunktLocalPropertyEnvironmentPostProcessor.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/spring/IntegrasjonspunktLocalPropertyEnvironmentPostProcessor.java
@@ -1,9 +1,10 @@
 package no.difi.meldingsutveksling.spring;
 
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.boot.logging.DeferredLog;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -13,21 +14,19 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
 
 import java.io.IOException;
-import java.util.Optional;
 import java.util.Properties;
 
 /**
- *
  * @author kons-nlu
  */
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
-public class IntegrasjonspunktLocalPropertyEnvironmentPostProcessor implements EnvironmentPostProcessor, ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+public class IntegrasjonspunktLocalPropertyEnvironmentPostProcessor implements EnvironmentPostProcessor, ApplicationListener<ApplicationEvent> {
 
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(IntegrasjonspunktLocalPropertyEnvironmentPostProcessor.class);
+    private static final DeferredLog log = new DeferredLog();
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-        if (Optional.ofNullable(environment.getProperty("app.local.properties.enable", Boolean.class)).orElse(true).booleanValue() == false) {
+        if (!environment.getProperty("app.local.properties.enable", Boolean.class, true)) {
             log.info("Disable local properties file for test");
             return;
         }
@@ -42,8 +41,11 @@ public class IntegrasjonspunktLocalPropertyEnvironmentPostProcessor implements E
     }
 
     @Override
-    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent e) {
-        this.postProcessEnvironment(e.getEnvironment(), e.getSpringApplication());
+    public void onApplicationEvent(ApplicationEvent e) {
+        if (e instanceof ApplicationEnvironmentPreparedEvent) {
+            ApplicationEnvironmentPreparedEvent ee = (ApplicationEnvironmentPreparedEvent) e;
+            this.postProcessEnvironment(ee.getEnvironment(), ee.getSpringApplication());
+        }
+        log.replayTo(IntegrasjonspunktLocalPropertyEnvironmentPostProcessor.class);
     }
-
 }


### PR DESCRIPTION
Det ble forsøkt logget en error om at filen ikke finnes, men problemet er at loggingen ikke er initialisert så tidlig. Har derfor laget en løsning med delayed logging, som replayes via application events. Resulatet er at feilmeldingen synes i loggen.