### PR TITLE
MOVE-2979 Slått av autocommit som standard på Hikari JDBC connection …

### DIFF
--- a/integrasjonspunkt/src/main/resources/config/application.properties
+++ b/integrasjonspunkt/src/main/resources/config/application.properties
@@ -319,3 +319,5 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Europe/Oslo
 spring.datasource.hikari.maximum-pool-size=50
 
 server.connection-timeout=300000
+
+spring.datasource.hikari.autoCommit=false


### PR DESCRIPTION
…pool fordi det er unødvendig og i enkelte situasjoner skaper problem