### PR TITLE
feat: MOVE-3200: New default print provider

### DIFF
--- a/integrasjonspunkt/src/main/resources/config/application-production.properties
+++ b/integrasjonspunkt/src/main/resources/config/application-production.properties
@@ -39,7 +39,7 @@ difi.move.nextmove.service-bus.pollingrate=20000
 # DPI
 difi.move.dpi.endpoint=https://meldingsformidler.digipost.no/api/ebms
 difi.move.dpi.uri=https://srest.dataplatfor.ms/dpi
-difi.move.dpi.krr-print-url=https://krr.digdir.no/rest/v1/printSertifikat
+difi.move.dpi.krr-print-url=https://krr.digdir.no/rest/v2/printSertifikat
 difi.move.dpi.certificate.recipe=classpath:/pki/recipe-dpi-norway-production.xml
 difi.move.dpi.mpcId=no.difi.move.integrasjonspunkt
 

--- a/integrasjonspunkt/src/main/resources/config/application.properties
+++ b/integrasjonspunkt/src/main/resources/config/application.properties
@@ -99,7 +99,7 @@ difi.move.dpi.printSettings.shippingType=ECONOMY
 difi.move.dpi.upload-size-limit=150MB
 difi.move.dpi.client-type=xmlsoap
 difi.move.dpi.clientMaxConnectionPoolSize=10
-difi.move.dpi.krr-print-url=https://test.kontaktregisteret.no/rest/v1/printSertifikat
+difi.move.dpi.krr-print-url=https://test.kontaktregisteret.no/rest/v2/printSertifikat
 difi.move.dpi.uri=https://srest.qa.dataplatfor.ms/dpi
 
 difi.move.dpi.c2-type=web


### PR DESCRIPTION
- Replace Posten with Skatteetaten as default print provider in eFormidling.