### PR TITLE
MOVE-4972, return json instead of only part of error

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/ProblemDetailsParser.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/ProblemDetailsParser.java
@@ -15,18 +15,16 @@ public class ProblemDetailsParser {
     public static String parseClientHttpResponse(String prefix, ClientHttpResponse response) {
         var jsonAsString = "NoProblemDetails";
         try {
-            var objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+//            var objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             var bodyAsBytes = response.getBody().readAllBytes();
             if (bodyAsBytes.length == 0) return "%s: %d %s, %s".formatted(prefix, response.getStatusCode().value(), response.getStatusCode().toString(), "No body returned");
             jsonAsString = new String(bodyAsBytes, StandardCharsets.UTF_8);
-            var problemDetails = objectMapper.readValue(jsonAsString, ProblemDetails.class);
-            if (problemDetails.getTitle() == null) problemDetails.setTitle("No title was given");
-            if (problemDetails.getDetail() == null) problemDetails.setDetail("Response was : " + jsonAsString);
-            return "%s: %d %s, %s".formatted(
+//            var problemDetails = objectMapper.readValue(jsonAsString, ProblemDetails.class);
+//            if (problemDetails.getTitle() == null) problemDetails.setTitle("No title was given");
+//            if (problemDetails.getDetail() == null) problemDetails.setDetail("Response was : " + jsonAsString);
+            return "%s: %s".formatted(
                 prefix,
-                problemDetails.getStatus(),
-                problemDetails.getTitle(),
-                problemDetails.getDetail()
+                jsonAsString
             );
         } catch (Exception e) {
             return "Unable to parse as Altinn ProblemDetails: " + e.getMessage() + "(" + jsonAsString + ")";

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/ProblemDetailsParserTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/ProblemDetailsParserTest.java
@@ -21,16 +21,22 @@ class ProblemDetailsParserTest {
     void parseProblemDetails_ok() throws Exception {
 
         when(clientHttpResponse.getBody()).thenReturn(new ByteArrayInputStream("""
-                {
-                    "type":"https://datatracker.ietf.org/doc/html/rfc7807",
-                    "title":"Unauthorized",
-                    "status":401,
-                    "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry"
-                }""".getBytes()));
+            {
+                "type":"https://datatracker.ietf.org/doc/html/rfc7807",
+                "title":"Unauthorized",
+                "status":401,
+                "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry"
+            }""".getBytes()));
 
         var actual = ProblemDetailsParser.parseClientHttpResponse("TestRun", clientHttpResponse);
 
-        assertEquals("TestRun: 401 Unauthorized, You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry", actual);
+        assertEquals("""
+            TestRun: {
+                "type":"https://datatracker.ietf.org/doc/html/rfc7807",
+                "title":"Unauthorized",
+                "status":401,
+                "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry"
+            }""", actual);
 
     }
 
@@ -38,17 +44,24 @@ class ProblemDetailsParserTest {
     void parseProblemDetails_ok_with_unknown_property_traceId() throws Exception {
 
         when(clientHttpResponse.getBody()).thenReturn(new ByteArrayInputStream("""
-                {
-                    "type":"https://tools.ietf.org/html/rfc9110#section-15.5.2",
-                    "title":"Unauthorized",
-                    "status":401,
-                    "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry",
-                    "traceId":"00-5f87f02bb2dac47bd8791b7e511ece2c-34c74bd580503f64-01"
-                }""".getBytes()));
+            {
+                "type":"https://tools.ietf.org/html/rfc9110#section-15.5.2",
+                "title":"Unauthorized",
+                "status":401,
+                "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry",
+                "traceId":"00-5f87f02bb2dac47bd8791b7e511ece2c-34c74bd580503f64-01"
+            }""".getBytes()));
 
         var actual = ProblemDetailsParser.parseClientHttpResponse("TestRun", clientHttpResponse);
 
-        assertEquals("TestRun: 401 Unauthorized, You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry", actual);
+        assertEquals("""
+            TestRun: {
+                "type":"https://tools.ietf.org/html/rfc9110#section-15.5.2",
+                "title":"Unauthorized",
+                "status":401,
+                "detail":"You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry",
+                "traceId":"00-5f87f02bb2dac47bd8791b7e511ece2c-34c74bd580503f64-01"
+            }""", actual);
 
     }
 
@@ -61,7 +74,7 @@ class ProblemDetailsParserTest {
         var actual = ProblemDetailsParser.parseClientHttpResponse("TestRun", clientHttpResponse);
 
         assertEquals("""
-            TestRun: null No title was given, Response was : {"unknown" : "value"}""", actual);
+            TestRun: {"unknown" : "value"}""", actual);
 
     }
 
@@ -69,13 +82,11 @@ class ProblemDetailsParserTest {
     void parseProblemDetails_error_parsing_non_json() throws Exception {
 
         when(clientHttpResponse.getBody()).thenReturn(new ByteArrayInputStream("""
-                NoJsonAtAll""".getBytes()));
+            NoJsonAtAll""".getBytes()));
 
         var actual = ProblemDetailsParser.parseClientHttpResponse("TestRun", clientHttpResponse);
 
-        assertEquals("""
-            Unable to parse as Altinn ProblemDetails: Unrecognized token 'NoJsonAtAll': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-             at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1](NoJsonAtAll)""", actual);
+        assertEquals( "TestRun: NoJsonAtAll", actual);
 
     }
 


### PR DESCRIPTION
Altinn sin openapi spec er ikkje oppdatert med all dataen dei returnerer, så den automatisk genererte ProblemDetails er ukomplett og vi mister data når vi parser. Fram til vi får komplett openapi spec så returnerer vi heile json istedenfor.