### PR TITLE
MOVE-4982 - Fix error for DPV messages sent with Altinn 2 befor 4.x.x upgrde

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
@@ -37,7 +37,13 @@ public class AltinnDPVService {
     }
 
     public List<CorrespondenceStatusEventExt> getStatus(Conversation conversation){
-        return client.getCorrespondenceDetails(UUID.fromString(conversation.getExternalSystemReference()))
+        var correspondenceId = conversation.getExternalSystemReference();
+
+        if(correspondenceId == null || correspondenceId.isEmpty()) {
+            throw new InvalidConversationReferenceException("Missing correspondenceId in conversation reference for conversation " + conversation.getConversationId());
+        }
+
+        return client.getCorrespondenceDetails(UUID.fromString(correspondenceId))
             .getStatusHistory();
     }
 

--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/InvalidConversationReferenceException.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/InvalidConversationReferenceException.java
@@ -1,0 +1,7 @@
+package no.difi.meldingsutveksling.altinnv3.dpv;
+
+public class InvalidConversationReferenceException extends RuntimeException {
+    public InvalidConversationReferenceException(String message) {
+        super(message);
+    }
+}

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
@@ -8,6 +8,7 @@ import no.difi.meldingsutveksling.nextmove.BusinessMessageFile;
 import no.difi.meldingsutveksling.nextmove.NextMoveOutMessage;
 import no.difi.meldingsutveksling.serviceregistry.externalmodel.Service;
 import no.difi.meldingsutveksling.serviceregistry.externalmodel.ServiceRecord;
+import no.difi.meldingsutveksling.status.Conversation;
 import no.digdir.altinn3.correspondence.model.BaseCorrespondenceExt;
 import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesExt;
 import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesResponseExt;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +77,19 @@ public class AltinnDPVServiceTest {
 
         assertEquals(correspondenceId, result, "The returned value needs to be the correspondence id of the correspondence");
         verify(correspondenceApiClient).upload(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void getStatusThrowsErrorWhenExternalSystemReferenceIsMissing(){
+        Conversation conversation = new Conversation();
+        conversation.setConversationId("abc");
+        conversation.setExternalSystemReference(null); // When message has been sent with IP older than 4.x.x, the message will not have an external system reference
+
+        var exception = assertThrows(InvalidConversationReferenceException.class, () -> {
+            altinnDPVService.getStatus(conversation);
+        });
+
+        assertEquals("Missing correspondenceId in conversation reference for conversation abc", exception.getMessage());
     }
 
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
@@ -2,6 +2,7 @@ package no.difi.meldingsutveksling.receipt.strategy;
 
 import no.difi.meldingsutveksling.ServiceIdentifier;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.InvalidConversationReferenceException;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.NextMoveQueue;
 import no.difi.meldingsutveksling.api.StatusStrategy;
@@ -62,6 +63,19 @@ public class DpvStatusStrategy implements StatusStrategy {
             try {
                 List<CorrespondenceStatusEventExt> statuses = altinnService.getStatus(conversation);
                 updateStatus(conversation, statuses);
+            } catch (InvalidConversationReferenceException e) {
+                log.warn("""
+                    {}
+                    The message has probably been sent with an earlier version of Integrasjonspunkt than 4.x.x, using the old Altinn api.
+                    Can't fetch statuses for the conversation. Setting conversation as finished and stops polling for this conversation.
+                    """, e.getMessage())
+                ;
+
+                conversation.setPollable(false);
+                conversation.setFinished(true);
+
+                conversationService.save(conversation);
+
             } catch (Exception e) {
                 log.error("Error during status check for " + conversation.getConversationId(), e);
             }

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
@@ -1,18 +1,63 @@
 package no.difi.meldingsutveksling.receipt.strategy;
 
-import lombok.extern.slf4j.Slf4j;
+import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.InvalidConversationReferenceException;
+import no.difi.meldingsutveksling.api.ConversationService;
+import no.difi.meldingsutveksling.api.NextMoveQueue;
+import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
+import no.difi.meldingsutveksling.sbd.SBDFactory;
+import no.difi.meldingsutveksling.status.Conversation;
+import no.difi.meldingsutveksling.status.MessageStatusFactory;
 import no.digdir.altinn3.correspondence.model.CorrespondenceStatusExt;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static no.difi.meldingsutveksling.receipt.ReceiptStatus.*;
 import static no.difi.meldingsutveksling.receipt.strategy.DpvStatusStrategy.mapCorrespondenceStatusToReceiptStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@Slf4j
+@ExtendWith(MockitoExtension.class)
 class DpvStatusStrategyTest {
+
+    @InjectMocks
+    private DpvStatusStrategy dpvStatusStrategy;
+    @Mock
+    private ConversationService conversationService;
+    @Mock
+    private MessageStatusFactory messageStatusFactory;
+    @Mock
+    private SBDFactory sbdFactory;
+    @Mock
+    private IntegrasjonspunktProperties properties;
+    @Mock
+    private NextMoveQueue nextMoveQueue;
+    @Mock
+    private AltinnDPVService altinnService;
+
+    @Test
+    public void whenInvalidConversationReferenceExceptionStopPolling() {
+        Conversation conversation = new Conversation();
+        conversation.setPollable(true);
+        conversation.setFinished(false);
+
+        Mockito.when(altinnService.getStatus(conversation)).thenThrow(new InvalidConversationReferenceException("test"));
+
+        dpvStatusStrategy.checkStatus(Set.of(conversation));
+
+        assertTrue(conversation.isFinished(), "The conversation should be marked as finished when InvalidConversationReferenceException is thrown");
+        assertFalse(conversation.isPollable(), "The conversation should not be pollable when InvalidConversationReferenceException is thrown");
+        Mockito.verify(conversationService, Mockito.times(1)).save(conversation);
+    }
 
     @Test
     void verifyMappings() {


### PR DESCRIPTION
Etter diskusjon med @DanielFylling kom vi fram til at vi ikkje endrer status på meldingen (Typ "Feil", "Levetid utløpt" etc.) siden det kan gi uønska bivirkninger (epostutsendelse) eller feil i statestikk og sånne ting.