### PR TITLE
MOVE-Allow trailing slash property. Needed for Tieto and P360.

### DIFF
--- a/common-spring/src/main/java/no/difi/meldingsutveksling/config/IntegrasjonspunktProperties.java
+++ b/common-spring/src/main/java/no/difi/meldingsutveksling/config/IntegrasjonspunktProperties.java
@@ -300,6 +300,7 @@ public class IntegrasjonspunktProperties {
         private boolean retryOnDeadLock;
         private boolean cryptoMessagePersister;
         private Set<ServiceIdentifier> statusQueueIncludes = Sets.newHashSet();
+        private boolean allowDeprecatedTrailingSlash;
 
         /**
          * Service toggles

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/MvcConfiguration.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/MvcConfiguration.java
@@ -3,9 +3,11 @@ package no.difi.meldingsutveksling.config;
 import lombok.RequiredArgsConstructor;
 import no.difi.meldingsutveksling.converter.MultipartFileToStandardBusinessDocumentConverter;
 import no.difi.meldingsutveksling.converter.StringToStandardBusinessDocumentConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -16,9 +18,19 @@ public class MvcConfiguration implements WebMvcConfigurer {
     private final StringToStandardBusinessDocumentConverter stringToStandardBusinessDocumentConverter;
     private final MultipartFileToStandardBusinessDocumentConverter multipartFileToStandardBusinessDocumentConverter;
 
+    @Value("${difi.move.feature.allowDeprecatedTrailingSlash:false}")
+    private boolean allowDeprecatedTrailingSlash;
+
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(stringToStandardBusinessDocumentConverter);
         registry.addConverter(multipartFileToStandardBusinessDocumentConverter);
+    }
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        if (allowDeprecatedTrailingSlash) {
+            configurer.setUseTrailingSlashMatch(true);
+        }
     }
 }


### PR DESCRIPTION
<img width="1146" height="436" alt="image" src="https://github.com/user-attachments/assets/f550e159-ee19-4145-82fc-4a636e7731dc" />

Bruker `setUseTrailingSlashMatch` som er deprecated og fjerna fra Spring Boot 4. Om vi kommer oss over på Spring Boot 4 eingang så bør ikkje det vere lengre behov for trailing slash


Testa med url-ene http://localhost:9093/api/messages/out/multipart/, http://localhost:9093/api/messages/in/peek/ og http://localhost:9093/jwk/

