### PR TITLE
MOVE-Added a connection check for DPO reportees

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpo/ReporteesConnectionCheck.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpo/ReporteesConnectionCheck.java
@@ -1,0 +1,35 @@
+package no.difi.meldingsutveksling.altinnv3.dpo;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@ConditionalOnProperty(name = "difi.move.feature.enableDPO", havingValue = "true")
+public class ReporteesConnectionCheck {
+    private final IntegrasjonspunktProperties properties;
+    private final AltinnDPODownloadService altinnDownloadService;
+
+    @PostConstruct
+    public void reporteesConnectionCheck() {
+        var reporteesSystemUsers = properties.getDpo().getReportees();
+
+        if(!reporteesSystemUsers.isEmpty()) {
+            log.info("Performing a connection test for reportees defined in properties by polling for DPO messages");
+            reporteesSystemUsers.forEach(system -> {
+                log.info("Connection test for systemUser:{}", system);
+                try {
+                    altinnDownloadService.getAvailableFiles(system);
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                        "Failed to poll messages from Altinn for system: " + system + ". The system user configuration might be wrong", e);
+                }
+            });
+        }
+    }
+}

--- a/common-spring/src/main/java/no/difi/meldingsutveksling/config/AltinnFormidlingsTjenestenConfig.java
+++ b/common-spring/src/main/java/no/difi/meldingsutveksling/config/AltinnFormidlingsTjenestenConfig.java
@@ -51,6 +51,7 @@ public class AltinnFormidlingsTjenestenConfig {
     /**
      * Altinn liste av ekstra systembrukere (reportees) som det også skal behandles meldinger for
      */
+    @Valid
     private Set<AltinnSystemUser> reportees = Sets.newHashSet();
 
 }

--- a/common-spring/src/main/java/no/difi/meldingsutveksling/config/AltinnSystemUser.java
+++ b/common-spring/src/main/java/no/difi/meldingsutveksling/config/AltinnSystemUser.java
@@ -1,5 +1,6 @@
 package no.difi.meldingsutveksling.config;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,12 @@ public class AltinnSystemUser {
     /**
      * format : 0192:311780735
      */
+    @NotNull
     private String orgId;
     /**
      * eks : 311780735_integrasjonspunkt_systembruker_test
      */
+    @NotNull
     private String name;
 
 }


### PR DESCRIPTION
Sjekker kun for systembrukerene for reportees og ikkje hoved systembrukaren. Hoved systembrukaren kan opprettes gjennom GUI til integrasjonspunktet, og har ein default verdi om man ikkje setter den sjølv i properties filene.