### PR TITLE
MOVE-chore Update latest version to v4.0.4 for Kosmos

### DIFF
--- a/latest-versions.yml
+++ b/latest-versions.yml
@@ -6,14 +6,14 @@
 integrasjonspunkt:
   environments:
     dev:
-      latest: v4.0.3
+      latest: v4.0.4
       earlybird: v4.1.0-beta
     itest:
-      latest: v4.0.3
+      latest: v4.0.4
       earlybird: v4.1.0-beta
     staging:
-      latest: v4.0.3
+      latest: v4.0.4
       earlybird: v4.1.0-beta
     production:
-      latest: v4.0.3
+      latest: v4.0.4
       earlybird: v4.1.0-beta


### PR DESCRIPTION
After release of v4.0.4 we need to update this file so that Kosmos can download the new version.