### PR TITLE
MOVE-5081 Fetching DPV status from correspondence overview

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import no.difi.meldingsutveksling.nextmove.NextMoveOutMessage;
 import no.difi.meldingsutveksling.status.Conversation;
 import no.digdir.altinn3.correspondence.model.CorrespondenceStatusEventExt;
+import no.digdir.altinn3.correspondence.model.CorrespondenceStatusExt;
 import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesExt;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -36,15 +39,24 @@ public class AltinnDPVService {
         return result.getCorrespondences().getFirst().getCorrespondenceId();
     }
 
-    public List<CorrespondenceStatusEventExt> getStatus(Conversation conversation){
+    public List<CorrespondenceStatusEventExt> getStatus(Conversation conversation) {
         var correspondenceId = conversation.getExternalSystemReference();
 
-        if(correspondenceId == null || correspondenceId.isEmpty()) {
+        if (correspondenceId == null || correspondenceId.isEmpty()) {
             throw new InvalidConversationReferenceException("Missing correspondenceId in conversation reference for conversation " + conversation.getConversationId());
         }
 
-        return client.getCorrespondenceDetails(UUID.fromString(correspondenceId))
-            .getStatusHistory();
+        List<CorrespondenceStatusEventExt> statusEvents = new ArrayList<>();
+        var overview = client.getCorrespondenceOverview(UUID.fromString(correspondenceId));
+        statusEvents.add(createStatusEvent(CorrespondenceStatusExt.INITIALIZED, overview.getCreated()));
+        if (overview.getPublished() != null) statusEvents.add(createStatusEvent(CorrespondenceStatusExt.PUBLISHED, overview.getPublished()));
+        if (overview.getRead() != null) statusEvents.add(createStatusEvent(CorrespondenceStatusExt.READ, overview.getRead()));
+        return statusEvents;
+
+    }
+
+    private CorrespondenceStatusEventExt createStatusEvent(CorrespondenceStatusExt status, OffsetDateTime timestamp) {
+        return new CorrespondenceStatusEventExt().status(status).statusChanged(timestamp).statusText(status.getValue());
     }
 
 }

--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.difi.meldingsutveksling.altinnv3.ProblemDetailsParser;
 import no.difi.meldingsutveksling.altinnv3.token.TokenProducer;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
-import no.digdir.altinn3.correspondence.model.AttachmentDetailsExt;
-import no.digdir.altinn3.correspondence.model.CorrespondenceDetailsExt;
-import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesExt;
-import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesResponseExt;
+import no.digdir.altinn3.correspondence.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpRequest;
@@ -83,15 +80,29 @@ public class CorrespondenceApiClient {
             ;
     }
 
+    // dette er en "tung" operasjon hos Altinn (påvirker Dialogporten og Notification også), bruk med måte
     public CorrespondenceDetailsExt getCorrespondenceDetails(UUID correspondenceId) {
         String accessToken = tokenProducer.produceToken(scopes);
-
+        log.debug("Fetching details for correspondenceId {} from Altinn Correspondence API", correspondenceId);
         return restClient.get()
             .uri(correspondenceServiceUrl + "/correspondence/{correspondenceId}/details", correspondenceId)
             .header("Authorization", "Bearer " + accessToken)
             .header("Accept", "application/json")
             .retrieve()
             .body(CorrespondenceDetailsExt.class)
+            ;
+    }
+
+    // dette er en "rask" operasjon hos Altinn (benytt denne fremfor getCorrespondenceDetails der det er mulig)
+    public CorrespondenceOverviewExt getCorrespondenceOverview(UUID correspondenceId) {
+        String accessToken = tokenProducer.produceToken(scopes);
+        log.debug("Fetching overview for correspondenceId {} from Altinn Correspondence API", correspondenceId);
+        return restClient.get()
+            .uri(correspondenceServiceUrl + "/correspondence/{correspondenceId}", correspondenceId)
+            .header("Authorization", "Bearer " + accessToken)
+            .header("Accept", "application/json")
+            .retrieve()
+            .body(CorrespondenceOverviewExt.class)
             ;
     }
 

--- a/altinn-v3-client/src/main/resources/openapi/altinn-correspondence-v1.json
+++ b/altinn-v3-client/src/main/resources/openapi/altinn-correspondence-v1.json
@@ -1976,7 +1976,6 @@
                     "created",
                     "recipient",
                     "resourceId",
-
                     "sendersReference"
                 ],
                 "type": "object",
@@ -1988,7 +1987,6 @@
                         "description": "The Resource Id associated with the correspondence service."
                     },
                     "sender": {
-
                         "type": "string",
                         "description": "The Sending organization of the correspondence.",
                         "nullable": true,
@@ -2001,7 +1999,7 @@
                         "description": "A reference used by senders and receivers to identify a specific Correspondence using external identification methods."
                     },
                     "messageSender": {
-                        "maxLength": 256,
+                        "maxLength": 255,
                         "minLength": 0,
                         "type": "string",
                         "description": "An alternative name for the sender of the correspondence. The name will be displayed instead of the organization name.",
@@ -2060,12 +2058,6 @@
                         "description": "Specifies whether the correspondence can override reservation against digital communication in KRR",
                         "nullable": true
                     },
-                    "published": {
-                        "type": "string",
-                        "description": "Is null until the correspondence is published.",
-                        "format": "date-time",
-                        "nullable": true
-                    },
                     "isConfirmationNeeded": {
                         "type": "boolean",
                         "description": "Specifies whether reading the correspondence needs to be confirmed by the recipient"
@@ -2114,6 +2106,18 @@
                         "type": "integer",
                         "description": "The identifier/reference from Altinn 2 for migrated correspondence. Will be null for correspondence created in Altinn 3.",
                         "format": "int32",
+                        "nullable": true
+                    },
+                    "published": {
+                        "type": "string",
+                        "description": "Is null until the correspondence is published.",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "read": {
+                        "type": "string",
+                        "description": "Timestamp for when the correspondence was first read by the recipient. Is null until the correspondence has been read.",
+                        "format": "date-time",
                         "nullable": true
                     }
                 },

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
@@ -9,10 +9,7 @@ import no.difi.meldingsutveksling.nextmove.NextMoveOutMessage;
 import no.difi.meldingsutveksling.serviceregistry.externalmodel.Service;
 import no.difi.meldingsutveksling.serviceregistry.externalmodel.ServiceRecord;
 import no.difi.meldingsutveksling.status.Conversation;
-import no.digdir.altinn3.correspondence.model.BaseCorrespondenceExt;
-import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesExt;
-import no.digdir.altinn3.correspondence.model.InitializeCorrespondencesResponseExt;
-import no.digdir.altinn3.correspondence.model.InitializedCorrespondencesExt;
+import no.digdir.altinn3.correspondence.model.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -90,6 +88,47 @@ public class AltinnDPVServiceTest {
         });
 
         assertEquals("Missing correspondenceId in conversation reference for conversation abc", exception.getMessage());
+    }
+
+    @Test
+    public void getStatusHistoryInProgressConvertedFromOverview(){
+        Conversation conversation = new Conversation();
+        conversation.setConversationId("019eca65-3f08-7007-83df-2cb0f31d4dd7");
+        conversation.setExternalSystemReference("019eca65-3ec9-78e0-ad1d-30c1326c6f31");
+
+         Mockito.when(correspondenceApiClient.getCorrespondenceOverview(Mockito.any())).thenReturn(
+             new CorrespondenceOverviewExt()
+                 .created(OffsetDateTime.parse("2026-06-01T10:10:10Z"))
+                 .published(OffsetDateTime.parse("2026-06-01T11:11:11Z"))
+         );
+
+        var history = altinnDPVService.getStatus(conversation);
+
+        assertEquals("Initialized", history.getFirst().getStatusText());
+        assertEquals(CorrespondenceStatusExt.PUBLISHED, history.getLast().getStatus());
+        assertEquals("Published", history.getLast().getStatusText());
+        assertEquals("2026-06-01T11:11:11Z", history.getLast().getStatusChanged().toString());
+    }
+
+    @Test
+    public void getStatusHistoryFinishedConvertedFromOverview(){
+        Conversation conversation = new Conversation();
+        conversation.setConversationId("019eca65-3f08-7007-83df-2cb0f31d4dd7");
+        conversation.setExternalSystemReference("019eca65-3ec9-78e0-ad1d-30c1326c6f31");
+
+        Mockito.when(correspondenceApiClient.getCorrespondenceOverview(Mockito.any())).thenReturn(
+            new CorrespondenceOverviewExt()
+                .created(OffsetDateTime.parse("2026-06-01T10:10:10Z"))
+                .published(OffsetDateTime.parse("2026-06-01T11:11:11Z"))
+                .read(OffsetDateTime.parse("2026-06-01T12:12:12Z"))
+        );
+
+        var history = altinnDPVService.getStatus(conversation);
+
+        assertEquals("Initialized", history.getFirst().getStatusText());
+        assertEquals(CorrespondenceStatusExt.PUBLISHED, history.get(1).getStatus());
+        assertEquals(CorrespondenceStatusExt.READ, history.getLast().getStatus());
+        assertEquals("2026-06-01T12:12:12Z", history.getLast().getStatusChanged().toString());
     }
 
 }

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/manualtests/ManuallyTestingCorrespondence.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/manualtests/ManuallyTestingCorrespondence.java
@@ -38,8 +38,8 @@ public class ManuallyTestingCorrespondence {
     @Inject
     CorrespondenceApiClient client;
 
-    String correspondenceId = "019980e6-e382-7eab-8c9d-60b9c7ccd116";
-    String attachmentId = "019980e6-e33a-7c11-9a04-22b864f31921";
+    String correspondenceId = "019eca65-3f08-7007-83df-2cb0f31d4dd7";
+    String attachmentId = "019eca65-3ec9-78e0-ad1d-30c1326c6f31";
 
     @Test
     public void upload() throws IOException {
@@ -89,6 +89,12 @@ public class ManuallyTestingCorrespondence {
     @Test
     public void getCorrespondenceDetails() {
         var res = client.getCorrespondenceDetails(UUID.fromString(correspondenceId));
+        System.out.println(res);
+    }
+
+    @Test
+    public void getCorrespondenceOverview() {
+        var res = client.getCorrespondenceOverview(UUID.fromString(correspondenceId));
         System.out.println(res);
     }
 

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/DpiClientTest.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/DpiClientTest.java
@@ -17,9 +17,7 @@ import no.difi.meldingsutveksling.domain.Iso6523;
 import no.difi.meldingsutveksling.domain.sbdh.Authority;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocument;
 import no.difi.meldingsutveksling.dpi.client.domain.*;
-import no.difi.meldingsutveksling.dpi.client.domain.messagetypes.BusinessMessage;
-import no.difi.meldingsutveksling.dpi.client.domain.messagetypes.Digital;
-import no.difi.meldingsutveksling.dpi.client.domain.messagetypes.Utskrift;
+import no.difi.meldingsutveksling.dpi.client.domain.messagetypes.*;
 import no.difi.meldingsutveksling.dpi.client.domain.sbd.*;
 import no.difi.meldingsutveksling.dpi.client.internal.DpiMapper;
 import no.difi.meldingsutveksling.dpi.client.internal.UnpackJWT;
@@ -67,8 +65,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.core.ConfigurationWhen.paths;
 import static net.javacrumbs.jsonunit.core.ConfigurationWhen.then;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -464,4 +461,26 @@ class DpiClientTest {
         assertThat(recordedRequest).isInstanceOf(HttpRequest.class);
         return (HttpRequest) recordedRequest;
     }
+
+    @Test
+    void verifyLombokChainingMagic() {
+
+        // Verify that Lombok's @Accessors(chain = true) works correctly on the BusinessMessage and its subclasses
+        // and that the setters return the correct type for chaining.  Since we don't have the @Accessors annotation
+        // this lombok feature is enabled using a global lombok.config file.
+
+        var d = new Digital();
+        assertThat(d).isInstanceOf(BusinessMessage.class);
+        assertThat(d).isInstanceOf(AvsenderHolder.class);
+        assertThat(d).isInstanceOf(PersonmottakerHolder.class);
+        assertThat(d).isInstanceOf(DokumentpakkefingeravtrykkHolder.class);
+        assertThat(d).isInstanceOf(MaskinportentokenHolder.class);
+
+        var bm = d.setMaskinportentoken("token");
+        assertThat(bm).isInstanceOf(Digital.class);
+        assertThat(bm).isInstanceOf(BusinessMessage.class);
+        assertThat(bm).isSameAs(d);
+
+    }
+
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/DpiReceiptHandler.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/DpiReceiptHandler.java
@@ -45,7 +45,7 @@ public class DpiReceiptHandler {
             if (ReceiptStatus.valueOf(status.getStatus()) == MOTTATT) {
                 if (conversation.get().getMessageStatuses().stream().noneMatch(ms -> ms.getStatus().equals("MOTTATT"))) {
                     conversationService.registerStatus(conversation.get(), status);
-                    log.debug(externalReceipt.logMarkers(), "Updated receipt (DPI)");
+                    log.debug(externalReceipt.logMarkers(), "Adjusted receipt (DPI)");
                 }
             } else {
                 conversationService.registerStatus(conversation.get(), status);


### PR DESCRIPTION
We need to switch status history from correspondence details (which is a very heavy Altinn operation) to the more light weight correspondence overview.

- updated openapi specification with the new expected field from Altinn v3
- added new rest client method
- converted overview response to match the status history we got from details response
- added tests for conversion
- added manual tests for easy debugging
- tweaking some log levels