### PR TITLE
Handle blank strings in DigitalDpvMessage fields

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceCreatorService.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceCreatorService.java
@@ -40,11 +40,13 @@ public class CorrespondenceCreatorService {
     private InitializeCorrespondencesExt handleDigitalDpvMessage(NextMoveOutMessage message, List<UUID> existingAttachments, List<BusinessMessageFile> newAttachmentsMetaData) {
         DigitalDpvMessage msg = (DigitalDpvMessage) message.getBusinessMessage();
 
-        var innhold = msg.getInnhold() != null ? msg.getInnhold() : "Ingen innhold";
+        var tittel = (msg.getTittel() != null && !msg.getTittel().isBlank()) ? msg.getTittel() : "Ingen tittel";
+        var sammendrag = (msg.getSammendrag() != null && !msg.getSammendrag().isBlank()) ? msg.getSammendrag() : tittel;
+        var innhold = (msg.getInnhold() != null && !msg.getInnhold().isBlank()) ? msg.getInnhold() : tittel;
 
         return correspondenceFactory.create(message,
-            msg.getTittel(),
-            msg.getSammendrag(),
+            tittel,
+            sammendrag,
             innhold,
             existingAttachments,
             newAttachmentsMetaData

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceCreatorServiceTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceCreatorServiceTest.java
@@ -57,7 +57,7 @@ public class CorrespondenceCreatorServiceTest {
     }
 
     @Test
-    public void create_fromDigitalDpvMessage_with_missing_innhold_use_default_text() {
+    public void create_fromDigitalDpvMessage_with_null_innhold_falls_back_to_tittel() {
         DigitalDpvMessage digitalDpvMessage = new DigitalDpvMessage();
         NextMoveOutMessage message = new NextMoveOutMessage();
         StandardBusinessDocument standardBusinessDocument = new StandardBusinessDocument();
@@ -71,7 +71,43 @@ public class CorrespondenceCreatorServiceTest {
 
         correspondenceCreatorService.create(message, null, null);
 
-        verify(correspondenceFactory).create(message, "Digital Dpv", "Digitalt sammendrag", "Ingen innhold", null, null);
+        verify(correspondenceFactory).create(message, "Digital Dpv", "Digitalt sammendrag", "Digital Dpv", null, null);
+    }
+
+    @Test
+    public void create_fromDigitalDpvMessage_with_blank_innhold_falls_back_to_tittel() {
+        DigitalDpvMessage digitalDpvMessage = new DigitalDpvMessage();
+        NextMoveOutMessage message = new NextMoveOutMessage();
+        StandardBusinessDocument standardBusinessDocument = new StandardBusinessDocument();
+
+        digitalDpvMessage.setTittel("Digital Dpv");
+        digitalDpvMessage.setSammendrag("Digitalt sammendrag");
+        digitalDpvMessage.setInnhold("");
+
+        standardBusinessDocument.setAny(digitalDpvMessage);
+        message.setSbd(standardBusinessDocument);
+
+        correspondenceCreatorService.create(message, null, null);
+
+        verify(correspondenceFactory).create(message, "Digital Dpv", "Digitalt sammendrag", "Digital Dpv", null, null);
+    }
+
+    @Test
+    public void create_fromDigitalDpvMessage_with_blank_sammendrag_falls_back_to_tittel() {
+        DigitalDpvMessage digitalDpvMessage = new DigitalDpvMessage();
+        NextMoveOutMessage message = new NextMoveOutMessage();
+        StandardBusinessDocument standardBusinessDocument = new StandardBusinessDocument();
+
+        digitalDpvMessage.setTittel("Digital Dpv");
+        digitalDpvMessage.setSammendrag("");
+        digitalDpvMessage.setInnhold("Digitalt innhold");
+
+        standardBusinessDocument.setAny(digitalDpvMessage);
+        message.setSbd(standardBusinessDocument);
+
+        correspondenceCreatorService.create(message, null, null);
+
+        verify(correspondenceFactory).create(message, "Digital Dpv", "Digital Dpv", "Digitalt innhold", null, null);
     }
 
     @Test


### PR DESCRIPTION
I forrige versjon ble det lagt til en sjekk for null:
var innhold = msg.getInnhold() != null ? msg.getInnhold() : "Ingen innhold";

Men feltet er allerede merket med @NotNull, så null kan aldri nå denne koden.
En tom streng ("") er ikke NULL og den passerer sjekken og sendes videre til Altinn 3 uendret, og gir HTTP 400

Foreslått endring:
Byttet sjekken fra != null til != null && !isBlank() for feltene innhold, sammendrag og tittel. Hvis ett av disse er null eller tomt/blankt, brukes tittel som reserveverdi slik at meldingen alltid har gyldig innhold og kommer frem.