### PR TITLE
Fix: popMessage delete is rolled back when asic.zip is missing

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageInService.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageInService.java
@@ -21,6 +21,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -63,7 +64,7 @@ public class NextMoveMessageInService {
         throw new NoContentException();
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Resource popMessage(String messageId) throws AsicPersistenceException {
         NextMoveInMessage message = messageRepo.findByMessageId(messageId)
             .orElseThrow(() -> new MessageNotFoundException(messageId));
@@ -95,7 +96,8 @@ public class NextMoveMessageInService {
             }
             messageRepo.delete(message);
             conversationService.registerStatus(messageId, ReceiptStatus.FEIL, errorMsg);
-            // throw checked AsicPersistanceException so that deletion transaction is not rolled back
+            // REQUIRES_NEW ensures this transaction commits before the controller's transaction
+            // can be rolled back by the FileNotFoundException it throws after catching this.
             throw new AsicPersistenceException();
         }
     }


### PR DESCRIPTION
## Problem

When a message's `asic.zip` file is missing or unreadable on disk, `popMessage()` catches the `IOException`, calls `messageRepo.delete()` to remove the corrupt message, then throws the checked `AsicPersistenceException`.

The intent was that a checked exception would prevent a transaction rollback. However, the controller's `popMessage` is also `@Transactional` (REQUIRED), so both methods share the same transaction. The controller catches `AsicPersistenceException` and rethrows it as `FileNotFoundException` (a RuntimeException), which causes Spring to roll back the shared transaction — taking the delete with it.

`NextMoveInMessageUnlocker` then releases the lock after timeout, and the message reappears on every subsequent peek. This produces an infinite retry loop where the same corrupt message is returned on every poll until the IP is restarted.

The `PersistenceException` branch already documents a similar problem in a code comment ("This cause database calls for `messageRepo.delete()` and `conversationService.registerStatus()` to fail."), but the `IOException` branch was incorrectly assumed to be safe because it throws a checked exception.

## Fix

Change the `@Transactional` propagation on `popMessage()` from `REQUIRED` to `REQUIRES_NEW`. The delete then runs in its own independent transaction and commits before control returns to the controller, regardless of what the controller does with its own transaction afterward.