### PR TITLE
Move-5116 Fjerna versjonslås på jakarta.persistence-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,12 +317,6 @@
                 <version>3.1.1</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.persistence</groupId>
-                <artifactId>jakarta.persistence-api</artifactId>
-                <!-- FIXME version 3.2.0 breaks cucumber tests -->
-                <version>3.1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>3.2.3</version>


### PR DESCRIPTION
Let Spring Boot BOM styra versjonen (3.1.0 på Boot 3.5). API 3.2 er inkompatibel med Hibernate 6.x (getSchemaManager()-konflikt gjer at Spring ikkje kan laga entityManagerFactory-proxyen), og kjem difor automatisk først med Boot 4 / Hibernate 7.