### PR TITLE
MOVE-5117 Rydda vekk API-bruk som er fjerna i Spring Framework 7

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/MvcConfiguration.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/config/MvcConfiguration.java
@@ -3,11 +3,12 @@ package no.difi.meldingsutveksling.config;
 import lombok.RequiredArgsConstructor;
 import no.difi.meldingsutveksling.converter.MultipartFileToStandardBusinessDocumentConverter;
 import no.difi.meldingsutveksling.converter.StringToStandardBusinessDocumentConverter;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.filter.UrlHandlerFilter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -18,19 +19,20 @@ public class MvcConfiguration implements WebMvcConfigurer {
     private final StringToStandardBusinessDocumentConverter stringToStandardBusinessDocumentConverter;
     private final MultipartFileToStandardBusinessDocumentConverter multipartFileToStandardBusinessDocumentConverter;
 
-    @Value("${difi.move.feature.allowDeprecatedTrailingSlash:false}")
-    private boolean allowDeprecatedTrailingSlash;
-
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(stringToStandardBusinessDocumentConverter);
         registry.addConverter(multipartFileToStandardBusinessDocumentConverter);
     }
 
-    @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
-        if (allowDeprecatedTrailingSlash) {
-            configurer.setUseTrailingSlashMatch(true);
-        }
+    /**
+     * Replaces PathMatchConfigurer.setUseTrailingSlashMatch(true), which is removed in
+     * Spring Framework 7. The filter transparently strips a trailing slash from incoming
+     * requests before handler mapping, preserving the deprecated trailing slash behaviour.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "difi.move.feature.allowDeprecatedTrailingSlash", havingValue = "true")
+    UrlHandlerFilter urlHandlerFilter() {
+        return UrlHandlerFilter.trailingSlashHandler("/**").wrapRequest().build();
     }
 }

--- a/integrasjonspunkt/src/main/resources/config/application.properties
+++ b/integrasjonspunkt/src/main/resources/config/application.properties
@@ -315,9 +315,6 @@ spring.jpa.open-in-view=false
 # make sure we continue in sequence legacy mode (Hibernate 5 as in IP v2.x)
 spring.jpa.properties.hibernate.id.db_structure_naming_strategy=legacy
 
-# streaming to database
-spring.jpa.properties.hibernate.current_session_context_class=org.springframework.orm.hibernate5.SpringSessionContext
-
 # logging to file
 logging.file.name=integrasjonspunkt-logs/application.log
 

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/config/MvcConfigurationTrailingSlashDisabledTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/config/MvcConfigurationTrailingSlashDisabledTest.java
@@ -1,0 +1,69 @@
+package no.difi.meldingsutveksling.config;
+
+import no.difi.meldingsutveksling.clock.ClockConfig;
+import no.difi.meldingsutveksling.nextmove.JacksonMockitoConfig;
+import no.difi.meldingsutveksling.oauth2.Oauth2ClientSecurityConfig;
+import no.difi.meldingsutveksling.status.Conversation;
+import no.difi.meldingsutveksling.status.ConversationQueryInput;
+import no.difi.meldingsutveksling.status.ConversationRepository;
+import no.difi.meldingsutveksling.status.service.ConversationController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the default behaviour when difi.move.feature.allowDeprecatedTrailingSlash is off:
+ * requests with a trailing slash do NOT match handlers mapped without one. See
+ * {@link MvcConfigurationTrailingSlashEnabledTest} for the behaviour with the flag enabled.
+ */
+@Import({ClockConfig.class, JacksonConfig.class, JacksonMockitoConfig.class, MvcConfiguration.class})
+@WebMvcTest({Oauth2ClientSecurityConfig.class, ConversationController.class})
+@ActiveProfiles("test")
+public class MvcConfigurationTrailingSlashDisabledTest {
+
+    @Autowired private MockMvc mvc;
+
+    @MockitoBean private ConversationRepository conversationRepository;
+
+    @Test
+    public void requestWithTrailingSlashDoesNotMatchHandler() throws Exception {
+        givenConversations();
+
+        mvc.perform(
+                get("/api/conversations/")
+                        .with(SecurityMockMvcRequestPostProcessors.httpBasic("testuser", "testpassword"))
+                        .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void requestWithoutTrailingSlashMatchesHandler() throws Exception {
+        givenConversations();
+
+        mvc.perform(
+                get("/api/conversations")
+                        .with(SecurityMockMvcRequestPostProcessors.httpBasic("testuser", "testpassword"))
+                        .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
+    private void givenConversations() {
+        given(conversationRepository.findWithMessageStatuses(any(ConversationQueryInput.class), any(Pageable.class)))
+                .willAnswer(invocation -> new PageImpl<Conversation>(List.of(), invocation.getArgument(1), 0));
+    }
+}

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/config/MvcConfigurationTrailingSlashEnabledTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/config/MvcConfigurationTrailingSlashEnabledTest.java
@@ -1,0 +1,71 @@
+package no.difi.meldingsutveksling.config;
+
+import no.difi.meldingsutveksling.clock.ClockConfig;
+import no.difi.meldingsutveksling.nextmove.JacksonMockitoConfig;
+import no.difi.meldingsutveksling.oauth2.Oauth2ClientSecurityConfig;
+import no.difi.meldingsutveksling.status.Conversation;
+import no.difi.meldingsutveksling.status.ConversationQueryInput;
+import no.difi.meldingsutveksling.status.ConversationRepository;
+import no.difi.meldingsutveksling.status.service.ConversationController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that the UrlHandlerFilter registered by {@link MvcConfiguration} preserves the
+ * deprecated trailing slash matching when difi.move.feature.allowDeprecatedTrailingSlash is
+ * enabled. See {@link MvcConfigurationTrailingSlashDisabledTest} for the default behaviour.
+ */
+@Import({ClockConfig.class, JacksonConfig.class, JacksonMockitoConfig.class, MvcConfiguration.class})
+@WebMvcTest({Oauth2ClientSecurityConfig.class, ConversationController.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = "difi.move.feature.allowDeprecatedTrailingSlash=true")
+public class MvcConfigurationTrailingSlashEnabledTest {
+
+    @Autowired private MockMvc mvc;
+
+    @MockitoBean private ConversationRepository conversationRepository;
+
+    @Test
+    public void requestWithTrailingSlashMatchesHandler() throws Exception {
+        givenConversations();
+
+        mvc.perform(
+                get("/api/conversations/")
+                        .with(SecurityMockMvcRequestPostProcessors.httpBasic("testuser", "testpassword"))
+                        .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    public void requestWithoutTrailingSlashStillMatchesHandler() throws Exception {
+        givenConversations();
+
+        mvc.perform(
+                get("/api/conversations")
+                        .with(SecurityMockMvcRequestPostProcessors.httpBasic("testuser", "testpassword"))
+                        .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
+    private void givenConversations() {
+        given(conversationRepository.findWithMessageStatuses(any(ConversationQueryInput.class), any(Pageable.class)))
+                .willAnswer(invocation -> new PageImpl<Conversation>(List.of(), invocation.getArgument(1), 0));
+    }
+}

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/cucumber/ServiceBusInSteps.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/cucumber/ServiceBusInSteps.java
@@ -16,7 +16,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.net.URI;
@@ -44,7 +43,7 @@ public class ServiceBusInSteps {
 
     @And("^the ServiceBus has the message available$")
     public void theServiceBusHasTheMessageAvailable() throws IOException {
-        MultiValueMap<String, String> headers = new HttpHeaders();
+        HttpHeaders headers = new HttpHeaders();
         headers.add("BrokerProperties", "{ \"MessageId\" : \"1\", \"LockToken\" : \"T1\", \"SequenceNumber\" : \"S1\" }");
 
         Message message = messageInHolder.get();


### PR DESCRIPTION
- Erstatta setUseTrailingSlashMatch(true) med UrlHandlerFilter bak same feature-flagg (difi.move.feature.allowDeprecatedTrailingSlash), slik at konsumentar som kallar API-et med trailing slash framleis verkar
- La til testar som dekkjer trailing slash-åtferda med flagget av og på
- Sletta daud hibernate.current_session_context_class-property som peika på ein klasse fjerna i Spring 6 (ingenting kallar getCurrentSession())
- Bytta MultiValueMap-referanse til HttpHeaders i ServiceBusInSteps (HttpHeaders implementerer ikkje lenger MultiValueMap i Framework 7)