### PR TITLE
MOVE-5133 Break out of retry-loop for sending ved client errors

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,3 +31,15 @@ CVE-2026-54513 # com.fasterxml.jackson.core:jackson-databind, fiksa i 2.21.4 (Sp
 
 CVE-2026-42588 # org.apache.activemq:activemq-broker (Spring Boot-styrt versjon)
 CVE-2026-45505 # org.apache.activemq:activemq-broker (Spring Boot-styrt versjon)
+
+# io.netty:netty-codec / netty-codec-http
+CVE-2026-59901 # netty-codec-compression: infinite loop in bzip2 decoder (DoS)
+CVE-2026-55831 # netty-codec-http: DoS via SPDY SETTINGS frame processing
+CVE-2026-55833 # netty-codec-http: DoS via SPDY header decompression amplification
+CVE-2026-56745 # netty-codec-http: unbounded pooled ByteBuf allocation via SPDY-to-HTTP codec
+
+# org.postgresql:postgresql
+CVE-2026-54291 # pgjdbc: man-in-the-middle protection bypass via SCRAM-SHA-256-PLUS downgrade
+
+# com.fasterxml.jackson.core:jackson-core / tools.jackson.core:jackson-core
+GHSA-r7wm-3cxj-wff9 # jackson-core: async parser maxNumberLength bypass via chunked digit accumulation (incomplete fix for GHSA-72hv-8253-57qq)

--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
@@ -23,6 +23,7 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -141,10 +142,10 @@ public class CorrespondenceApiClient {
             ;
     }
 
-    private void getCorrespondenceApiException(HttpRequest request, ClientHttpResponse response) {
+    private void getCorrespondenceApiException(HttpRequest request, ClientHttpResponse response) throws IOException {
         var prefix = "Correspondence api error: %s [%s]".formatted(request.getURI(), request.getURI().getPath());
         var details = ProblemDetailsParser.parseClientHttpResponse(prefix, response);
-        throw new CorrespondenceApiException(details);
+        throw new CorrespondenceApiException(details, response.getStatusCode());
     }
 
     private void addJacksonAsConverter(List<HttpMessageConverter<?>> converters) {

--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiException.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiException.java
@@ -1,17 +1,31 @@
 package no.difi.meldingsutveksling.altinnv3.dpv;
 
+import lombok.Getter;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
 public class CorrespondenceApiException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
 
     public CorrespondenceApiException() {
         super();
+        this.statusCode = null;
     }
 
     public CorrespondenceApiException(String message) {
         super(message);
+        this.statusCode = null;
     }
 
     public CorrespondenceApiException(String message, Throwable cause) {
         super(message, cause);
+        this.statusCode = null;
+    }
+
+    public CorrespondenceApiException(String message, HttpStatusCode statusCode) {
+        super(message);
+        this.statusCode = statusCode;
     }
 
 }

--- a/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
+++ b/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
@@ -5,18 +5,15 @@ import lombok.Getter;
 @Getter
 public class QueueInterruptException extends RuntimeException {
 
-    private final Integer httpCode;
     private final boolean clientError;
 
     public QueueInterruptException(String message) {
         super(message);
-        this.httpCode = null;
         this.clientError = false;
     }
 
-    public QueueInterruptException(String message, int httpCode, boolean clientError) {
+    public QueueInterruptException(String message, boolean clientError) {
         super(message);
-        this.httpCode = httpCode;
         this.clientError = clientError;
     }
 

--- a/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
+++ b/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
@@ -1,20 +1,9 @@
 package no.difi.meldingsutveksling;
 
-import lombok.Getter;
-
-@Getter
 public class QueueInterruptException extends RuntimeException {
-
-    private final boolean clientError;
 
     public QueueInterruptException(String message) {
         super(message);
-        this.clientError = false;
-    }
-
-    public QueueInterruptException(String message, boolean clientError) {
-        super(message);
-        this.clientError = clientError;
     }
 
 }

--- a/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
+++ b/common/src/main/java/no/difi/meldingsutveksling/QueueInterruptException.java
@@ -1,9 +1,23 @@
 package no.difi.meldingsutveksling;
 
+import lombok.Getter;
+
+@Getter
 public class QueueInterruptException extends RuntimeException {
+
+    private final Integer httpCode;
+    private final boolean clientError;
 
     public QueueInterruptException(String message) {
         super(message);
+        this.httpCode = null;
+        this.clientError = false;
+    }
+
+    public QueueInterruptException(String message, int httpCode, boolean clientError) {
+        super(message);
+        this.httpCode = httpCode;
+        this.clientError = clientError;
     }
 
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.difi.meldingsutveksling.QueueInterruptException;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
 import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
+import no.difi.meldingsutveksling.altinnv3.dpv.WithLogstashMarker;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.DpvConversationStrategy;
 import no.difi.meldingsutveksling.domain.sbdh.SBDUtil;
@@ -14,7 +15,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import no.difi.meldingsutveksling.altinnv3.dpv.WithLogstashMarker;
 
 import java.util.UUID;
 
@@ -48,7 +48,7 @@ public class DpvConversationStrategyImpl implements DpvConversationStrategy {
                     .execute(() -> altinnService.send(message));
         } catch (CorrespondenceApiException e) {
             if (e.getStatusCode() != null && e.getStatusCode().is4xxClientError()) {
-                throw new QueueInterruptException(e.getMessage(), e.getStatusCode().value(), true);
+                throw new QueueInterruptException(e.getMessage(), true);
             }
             throw e;
         }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
@@ -3,7 +3,9 @@ package no.difi.meldingsutveksling.nextmove;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.difi.meldingsutveksling.QueueInterruptException;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.DpvConversationStrategy;
 import no.difi.meldingsutveksling.domain.sbdh.SBDUtil;
@@ -40,8 +42,16 @@ public class DpvConversationStrategyImpl implements DpvConversationStrategy {
             return;
         }
 
-        UUID correspondenceid = WithLogstashMarker.withLogstashMarker(markerFrom(message))
-                .execute(() -> altinnService.send(message));
+        UUID correspondenceid;
+        try {
+            correspondenceid = WithLogstashMarker.withLogstashMarker(markerFrom(message))
+                    .execute(() -> altinnService.send(message));
+        } catch (CorrespondenceApiException e) {
+            if (e.getStatusCode() != null && e.getStatusCode().is4xxClientError()) {
+                throw new QueueInterruptException(e.getMessage(), e.getStatusCode().value(), true);
+            }
+            throw e;
+        }
 
         conversationService.findConversation(message.getMessageId())
             .ifPresent(conversation -> conversationService.save(conversation

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
@@ -48,7 +48,7 @@ public class DpvConversationStrategyImpl implements DpvConversationStrategy {
                     .execute(() -> altinnService.send(message));
         } catch (CorrespondenceApiException e) {
             if (e.getStatusCode() != null && e.getStatusCode().is4xxClientError()) {
-                throw new QueueInterruptException(e.getMessage(), true);
+                throw new QueueInterruptException(e.getMessage());
             }
             throw e;
         }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/InternalQueue.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/InternalQueue.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 @Slf4j
 public class InternalQueue {
 
-
     @Value("${difi.move.queue.nextmove-name}")
     private String nextmoveQueue;
 

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
@@ -12,9 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DpvConversationStrategyImplTest {
@@ -38,7 +36,6 @@ public class DpvConversationStrategyImplTest {
         QueueInterruptException exception = assertThrows(QueueInterruptException.class, () -> target.send(message));
 
         assertEquals("Bad request", exception.getMessage());
-        assertEquals(400, exception.getHttpCode());
         assertTrue(exception.isClientError());
         Mockito.verifyNoInteractions(conversationService);
     }

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
@@ -1,0 +1,59 @@
+package no.difi.meldingsutveksling.nextmove;
+
+import no.difi.meldingsutveksling.QueueInterruptException;
+import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
+import no.difi.meldingsutveksling.api.ConversationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class DpvConversationStrategyImplTest {
+
+    @InjectMocks
+    private DpvConversationStrategyImpl target;
+
+    @Mock
+    private ConversationService conversationService;
+
+    @Mock
+    private AltinnDPVService altinnService;
+
+    @Test
+    public void send_throwsQueueInterruptExceptionWhenAltinnRespondsWithClientError() {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        CorrespondenceApiException clientError = new CorrespondenceApiException("Bad request", HttpStatus.BAD_REQUEST);
+
+        Mockito.when(altinnService.send(message)).thenThrow(clientError);
+
+        QueueInterruptException exception = assertThrows(QueueInterruptException.class, () -> target.send(message));
+
+        assertEquals("Bad request", exception.getMessage());
+        assertEquals(400, exception.getHttpCode());
+        assertTrue(exception.isClientError());
+        Mockito.verifyNoInteractions(conversationService);
+    }
+
+    @Test
+    public void send_doesNotWrapServerErrorsInQueueInterruptException() {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        CorrespondenceApiException serverError = new CorrespondenceApiException("Internal error", HttpStatus.INTERNAL_SERVER_ERROR);
+
+        Mockito.when(altinnService.send(message)).thenThrow(serverError);
+
+        CorrespondenceApiException exception = assertThrows(CorrespondenceApiException.class, () -> target.send(message));
+
+        assertEquals(serverError, exception);
+        Mockito.verifyNoInteractions(conversationService);
+    }
+
+}

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
@@ -12,7 +12,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class DpvConversationStrategyImplTest {
@@ -36,7 +37,6 @@ public class DpvConversationStrategyImplTest {
         QueueInterruptException exception = assertThrows(QueueInterruptException.class, () -> target.send(message));
 
         assertEquals("Bad request", exception.getMessage());
-        assertTrue(exception.isClientError());
         Mockito.verifyNoInteractions(conversationService);
     }
 


### PR DESCRIPTION
Når Altinn correspondence API returnerer HTTP 4xx client error så havner meldingen tilbake på kø i en nær evig retry-loop i stedet for å settes til FEIL-status og puttes på DLQ.