### PR TITLE
MOVE-5106 Hindre evig heng ved polling av status

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -43,3 +43,8 @@ CVE-2026-54291 # pgjdbc: man-in-the-middle protection bypass via SCRAM-SHA-256-P
 
 # com.fasterxml.jackson.core:jackson-core / tools.jackson.core:jackson-core
 GHSA-r7wm-3cxj-wff9 # jackson-core: async parser maxNumberLength bypass via chunked digit accumulation (incomplete fix for GHSA-72hv-8253-57qq)
+
+# org.springframework: Spring Framework 6.2.18
+CVE-2026-41850 # spring-expression
+CVE-2026-41842 # spring-webmvc
+CVE-2026-41845 # xss

--- a/altinn-v3-client/src/test/resources/application.properties
+++ b/altinn-v3-client/src/test/resources/application.properties
@@ -1,10 +1,10 @@
 ## ORGANIZATION
 #difi.move.org.number=991825827
 
-## KEYSTORE for digdir
-difi.move.org.keystore.path=file:/Users/path/data/keystores/eformidling-test-auth.jks
-difi.move.org.keystore.alias=digdir-test-eformidling
-difi.move.org.keystore.password=password
+### KEYSTORE (husk file: prefix først i path))
+difi.move.org.keystore.alias=digdir_test_2029
+difi.move.org.keystore.password=BwFz2EvoxW8Kj4Ya
+difi.move.org.keystore.path=file:/Users/thorej/src/2026-cert-test-virks/cert-test-2029.jks
 
 ## KEYSTORE for hund
 #difi.move.org.keystore.path=file:./altinn3.jks

--- a/altinn-v3-client/src/test/resources/application.properties
+++ b/altinn-v3-client/src/test/resources/application.properties
@@ -2,9 +2,9 @@
 #difi.move.org.number=991825827
 
 ### KEYSTORE (husk file: prefix først i path))
-difi.move.org.keystore.alias=digdir_test_2029
-difi.move.org.keystore.password=BwFz2EvoxW8Kj4Ya
-difi.move.org.keystore.path=file:/Users/thorej/src/2026-cert-test-virks/cert-test-2029.jks
+difi.move.org.keystore.alias=alias
+difi.move.org.keystore.password=password
+difi.move.org.keystore.path=file:/Users/path/keystore.jks
 
 ## KEYSTORE for hund
 #difi.move.org.keystore.path=file:./altinn3.jks

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/DpiClientConfig.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/DpiClientConfig.java
@@ -37,6 +37,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.security.Security;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -107,7 +108,8 @@ public class DpiClientConfig {
                 createMaskinportenToken,
                 createMultipart,
                 resourceFactory,
-                properties.getPageSize());
+                properties.getPageSize(),
+                Duration.ofMillis(properties.getTimeout().getRead()));
 
     }
 

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/Corner2ClientImpl.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/Corner2ClientImpl.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -36,6 +37,7 @@ public class Corner2ClientImpl implements Corner2Client {
     private final CreateMultipart createMultipart;
     private final InMemoryWithTempFileFallbackResourceFactory resourceFactory;
     private final int pageSize;
+    private final Duration responseTimeout;
 
     @Override
     public void sendMessage(SendMessageInput input) {
@@ -51,6 +53,7 @@ public class Corner2ClientImpl implements Corner2Client {
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, this.dpiClientErrorHandler)
                 .toBodilessEntity()
+                .timeout(responseTimeout)
                 .block();
     }
 
@@ -61,7 +64,8 @@ public class Corner2ClientImpl implements Corner2Client {
                 .headers(h -> h.setBearerAuth(createMaskinportenToken.createMaskinportenTokenForReceiving()))
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, this.dpiClientErrorHandler)
-                .bodyToFlux(MessageStatus.class);
+                .bodyToFlux(MessageStatus.class)
+                .timeout(responseTimeout);
     }
 
     @Override
@@ -77,7 +81,8 @@ public class Corner2ClientImpl implements Corner2Client {
                 .headers(h -> h.setBearerAuth(createMaskinportenToken.createMaskinportenTokenForReceiving()))
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, this.dpiClientErrorHandler)
-                .bodyToFlux(Message.class);
+                .bodyToFlux(Message.class)
+                .timeout(responseTimeout);
     }
 
     @Override
@@ -92,7 +97,7 @@ public class Corner2ClientImpl implements Corner2Client {
 
         try (OutputStream outputStream = cms.getOutputStream()) {
             DataBufferUtils.write(dataBuffer, outputStream)
-                    .share().blockLast();
+                    .share().blockLast(responseTimeout);
         } catch (IOException e) {
             throw new DpiException(
                     "Downloading CMS encrypted archive failed for URL: %s".formatted(downloadurl),
@@ -113,6 +118,7 @@ public class Corner2ClientImpl implements Corner2Client {
                 .onStatus(HttpStatusCode::is5xxServerError, this.dpiClientErrorHandler)
                 .toBodilessEntity()
                 .onErrorResume(WebClientResponseException.NotFound.class, notFound -> Mono.empty())
+                .timeout(responseTimeout)
                 .block();
     }
 

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/Corner2ClientImplTest.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/Corner2ClientImplTest.java
@@ -1,0 +1,158 @@
+package no.difi.meldingsutveksling.dpi.client.internal;
+
+import no.difi.meldingsutveksling.dpi.client.domain.GetMessagesInput;
+import no.difi.meldingsutveksling.dpi.client.internal.domain.SendMessageInput;
+import no.difi.move.common.io.InMemoryWithTempFileFallbackResourceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerSettings;
+import org.mockserver.model.Delay;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+/**
+ * Verifies that {@link Corner2ClientImpl} bounds every blocking/reactive DPI call with
+ * {@code responseTimeout}, so a slow or unresponsive server fails fast instead of hanging the calling
+ * thread forever (possibly root cause behind a previously observed permanent stall of polling jobs).
+ */
+@MockServerSettings(ports = 8901)
+class Corner2ClientImplTest {
+
+    // Well below SERVER_DELAY, so every test below is guaranteed to hit the timeout rather than the response.
+    private static final Duration RESPONSE_TIMEOUT = Duration.ofMillis(300);
+    private static final Delay SERVER_DELAY = new Delay(TimeUnit.SECONDS, 5);
+    // Generous upper bound used to prove the call fails fast rather than hanging for SERVER_DELAY (or forever).
+    private static final Duration MAX_TEST_DURATION = Duration.ofSeconds(2);
+
+    private Corner2ClientImpl corner2Client;
+
+    @BeforeEach
+    void beforeEach() {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("http://localhost:8901")
+                .build();
+
+        corner2Client = new Corner2ClientImpl(
+                webClient,
+                new DpiClientErrorHandlerImpl(),
+                new CreateMaskinportenTokenMock("DummyMaskinportenToken"),
+                new CreateMultipart(),
+                InMemoryWithTempFileFallbackResourceFactory.builder().build(),
+                10,
+                RESPONSE_TIMEOUT);
+    }
+
+    @Test
+    void getMessageStatuses_timesOutInsteadOfHangingOnSlowServer(MockServerClient client) {
+        UUID messageId = UUID.randomUUID();
+        client.when(request()
+                        .withMethod("GET")
+                        .withPath("/messages/out/%s/statuses".formatted(messageId)))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withDelay(SERVER_DELAY));
+
+        StepVerifier.create(corner2Client.getMessageStatuses(messageId))
+                .expectError(TimeoutException.class)
+                .verify(MAX_TEST_DURATION);
+    }
+
+    @Test
+    void getMessages_timesOutInsteadOfHangingOnSlowServer(MockServerClient client) {
+        client.when(request()
+                        .withMethod("GET")
+                        .withPath("/messages/in"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withDelay(SERVER_DELAY));
+
+        StepVerifier.create(corner2Client.getMessages(new GetMessagesInput()))
+                .expectError(TimeoutException.class)
+                .verify(MAX_TEST_DURATION);
+    }
+
+    @Test
+    void sendMessage_timesOutInsteadOfHangingOnSlowServer(MockServerClient client) {
+        client.when(request()
+                        .withMethod("POST")
+                        .withPath("/messages/out"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withDelay(SERVER_DELAY));
+
+        SendMessageInput input = new SendMessageInput()
+                .setMaskinportentoken("token")
+                .setJwt("jwt")
+                .setCmsEncryptedAsice(new ByteArrayResource("asic".getBytes()));
+
+        assertTimesOutQuickly(() -> corner2Client.sendMessage(input));
+    }
+
+    @Test
+    void markAsRead_timesOutInsteadOfHangingOnSlowServer(MockServerClient client) {
+        UUID messageId = UUID.randomUUID();
+        client.when(request()
+                        .withMethod("POST")
+                        .withPath("/messages/in/%s/read".formatted(messageId)))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withDelay(SERVER_DELAY));
+
+        assertTimesOutQuickly(() -> corner2Client.markAsRead(messageId));
+    }
+
+    @Test
+    void getCmsEncryptedAsice_timesOutInsteadOfHangingOnSlowServer(MockServerClient client) {
+        String path = "/downloadmessage/%s".formatted(UUID.randomUUID());
+        client.when(request()
+                        .withMethod("GET")
+                        .withPath(path))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withBody("payload")
+                        .withDelay(SERVER_DELAY));
+
+        assertTimesOutQuickly(() -> corner2Client.getCmsEncryptedAsice(URI.create("http://localhost:8901" + path)));
+    }
+
+    /**
+     * Runs a blocking call and asserts it fails (with a timeout somewhere in the cause chain) well within
+     * MAX_TEST_DURATION, proving the calling thread is never left hanging on an unresponsive server.
+     */
+    private static void assertTimesOutQuickly(Runnable blockingCall) {
+        long start = System.nanoTime();
+        Throwable thrown = catchThrowable(blockingCall::run);
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+        assertThat(thrown).as("expected the call to fail due to the response timeout").isNotNull();
+        assertThat(elapsed)
+                .as("expected the call to fail fast instead of waiting out the slow server")
+                .isLessThan(MAX_TEST_DURATION);
+        assertThat(hasTimeoutCause(thrown))
+                .as("expected a timeout somewhere in the cause chain, but got: %s", thrown)
+                .isTrue();
+    }
+
+    private static boolean hasTimeoutCause(Throwable throwable) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t instanceof TimeoutException || t instanceof IllegalStateException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/status/StatusPolling.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/status/StatusPolling.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.groupingBy;
@@ -32,30 +33,44 @@ public class StatusPolling {
     private final StatusStrategyFactory statusStrategyFactory;
     private final ConversationStrategyFactory conversationStrategyFactory;
 
+    // Cron scheduling does not wait for the previous run to finish before firing the next one. Without this guard,
+    // a run that takes longer than the cron interval (e.g. a slow external channel) would overlap with the next run,
+    // both processing the same pollable conversations concurrently - risking duplicate receipts, e.g. duplicate
+    // arkivmelding-kvitteringer being enqueued for the same conversation.
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
     @Scheduled(cron = "${difi.move.nextmove.statusPollingCron}")
     public void checkReceiptStatus() {
         if (!props.getFeature().isEnableReceipts()) {
             return;
         }
-        int pageSize = props.getNextmove().getStatusPollingPageSize();
-        int pageIndex = 0;
+        if (!isRunning.compareAndSet(false, true)) {
+            log.warn("Skipping receipt status polling run - previous run has not finished yet");
+            return;
+        }
+        try {
+            int pageSize = props.getNextmove().getStatusPollingPageSize();
+            int pageIndex = 0;
 
-        Page<Long> page;
-        do {
-            // Uses paging for limiting memory footprint when polling for statuses for large batches of messages.
-            // Works around JPA limitation in combining paging and entity graph by making separate queries for page and
-            // entity graph. Ref "HHH000104: firstResult/maxResults specified with collection fetch; applying in
-            // memory!"
-            page = conversationRepository.findIdsForPollableConversations(PageRequest.of(pageIndex, pageSize));
-            Iterable<Conversation> conversations = conversationRepository.findAllById(page.getContent());
+            Page<Long> page;
+            do {
+                // Uses paging for limiting memory footprint when polling for statuses for large batches of messages.
+                // Works around JPA limitation in combining paging and entity graph by making separate queries for page and
+                // entity graph. Ref "HHH000104: firstResult/maxResults specified with collection fetch; applying in
+                // memory!"
+                page = conversationRepository.findIdsForPollableConversations(PageRequest.of(pageIndex, pageSize));
+                Iterable<Conversation> conversations = conversationRepository.findAllById(page.getContent());
 
-            StreamSupport.stream(conversations.spliterator(), false)
-                    .filter(c -> conversationStrategyFactory.isEnabled(c.getServiceIdentifier()))
-                    .collect(groupingBy(Conversation::getServiceIdentifier, toSet()))
-                    .forEach(this::checkReceiptForType);
+                StreamSupport.stream(conversations.spliterator(), false)
+                        .filter(c -> conversationStrategyFactory.isEnabled(c.getServiceIdentifier()))
+                        .collect(groupingBy(Conversation::getServiceIdentifier, toSet()))
+                        .forEach(this::checkReceiptForType);
 
-            pageIndex++;
-        } while (page.hasNext());
+                pageIndex++;
+            } while (page.hasNext());
+        } finally {
+            isRunning.set(false);
+        }
     }
 
     private void checkReceiptForType(ServiceIdentifier si, Set<Conversation> conversations) {
@@ -71,4 +86,5 @@ public class StatusPolling {
             MDC.clear();
         }
     }
+
 }


### PR DESCRIPTION
Se jira for analyse og detaljer, endringen ble kort fortalt :

- Setter read timeouts for DPI (hindrer at nettverkstrøbbel kan blokkere all status polling)
- Lagt til et “isRunning” flagg for å hindre at flere CRON jobber startes samtidig og jobber i "beina" på hverandre