### PR TITLE
MOVE-5132 - Stoppe polling av meldinger som er slettet i Altinn

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
@@ -85,7 +85,7 @@ public class DpvStatusStrategy implements StatusStrategy {
                             e.getStatusCode().value(), conversation.getMessageId(), conversation.getConversationId());
 
                     conversation.setPollable(false);
-                    conversationService.registerStatus(conversation, messageStatusFactory.getMessageStatus(ANNET));
+                    conversationService.registerStatus(conversation, messageStatusFactory.getMessageStatus(ANNET, "Melding slettet i Altinn, stopper polling."));
                 } else {
                     log.error("Error during status check for " + conversation.getConversationId(), e);
                 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
@@ -2,6 +2,7 @@ package no.difi.meldingsutveksling.receipt.strategy;
 
 import no.difi.meldingsutveksling.ServiceIdentifier;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
 import no.difi.meldingsutveksling.altinnv3.dpv.InvalidConversationReferenceException;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.NextMoveQueue;
@@ -20,6 +21,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -76,10 +79,25 @@ public class DpvStatusStrategy implements StatusStrategy {
 
                 conversationService.save(conversation);
 
+            } catch (CorrespondenceApiException e) {
+                if (isMessageDeleted(e.getStatusCode())) {
+                    log.warn("Correspondence api responded with status {} for message [messageId={}, conversationId={}], the message is probably deleted. Stopping polling for this message.",
+                            e.getStatusCode().value(), conversation.getMessageId(), conversation.getConversationId());
+
+                    conversation.setPollable(false);
+                    conversationService.registerStatus(conversation, messageStatusFactory.getMessageStatus(ANNET));
+                } else {
+                    log.error("Error during status check for " + conversation.getConversationId(), e);
+                }
             } catch (Exception e) {
                 log.error("Error during status check for " + conversation.getConversationId(), e);
             }
         }
+    }
+
+    private static boolean isMessageDeleted(@Nullable HttpStatusCode statusCode) {
+        return statusCode != null
+                && (statusCode.value() == HttpStatus.NOT_FOUND.value() || statusCode.value() == HttpStatus.GONE.value());
     }
 
     private void updateStatus(Conversation c, List<CorrespondenceStatusEventExt> status) {

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
@@ -1,20 +1,25 @@
 package no.difi.meldingsutveksling.receipt.strategy;
 
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
 import no.difi.meldingsutveksling.altinnv3.dpv.InvalidConversationReferenceException;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.NextMoveQueue;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
 import no.difi.meldingsutveksling.sbd.SBDFactory;
 import no.difi.meldingsutveksling.status.Conversation;
+import no.difi.meldingsutveksling.status.MessageStatus;
 import no.difi.meldingsutveksling.status.MessageStatusFactory;
 import no.digdir.altinn3.correspondence.model.CorrespondenceStatusExt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,9 +27,8 @@ import java.util.Set;
 
 import static no.difi.meldingsutveksling.receipt.ReceiptStatus.*;
 import static no.difi.meldingsutveksling.receipt.strategy.DpvStatusStrategy.mapCorrespondenceStatusToReceiptStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class DpvStatusStrategyTest {
@@ -59,6 +63,37 @@ class DpvStatusStrategyTest {
         Mockito.verify(conversationService, Mockito.times(1)).save(conversation);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {404, 410})
+    void whenMessageNotFoundOrGoneStopPollingAndRegisterAnnet(int statusCode) {
+        Conversation conversation = new Conversation();
+        conversation.setPollable(true);
+
+        MessageStatus annetStatus = MessageStatus.of(ANNET, null, null);
+        Mockito.when(altinnService.getStatus(conversation))
+                .thenThrow(new CorrespondenceApiException("not found", HttpStatus.valueOf(statusCode)));
+        Mockito.when(messageStatusFactory.getMessageStatus(ANNET)).thenReturn(annetStatus);
+
+        dpvStatusStrategy.checkStatus(Set.of(conversation));
+
+        assertFalse(conversation.isPollable(), "The conversation should not be pollable when the message is deleted");
+        Mockito.verify(conversationService, Mockito.times(1)).registerStatus(conversation, annetStatus);
+    }
+
+    @Test
+    void whenOtherCorrespondenceApiExceptionDoesNotStopPolling() {
+        Conversation conversation = new Conversation();
+        conversation.setPollable(true);
+
+        Mockito.when(altinnService.getStatus(conversation))
+                .thenThrow(new CorrespondenceApiException("server error", HttpStatus.INTERNAL_SERVER_ERROR));
+
+        dpvStatusStrategy.checkStatus(Set.of(conversation));
+
+        assertTrue(conversation.isPollable(), "The conversation should still be pollable for non 404/410 errors");
+        Mockito.verify(conversationService, Mockito.never()).registerStatus(eq(conversation), Mockito.any(MessageStatus.class));
+    }
+
     @Test
     void verifyMappings() {
 
@@ -66,7 +101,7 @@ class DpvStatusStrategyTest {
         assertEquals(ANNET, mapCorrespondenceStatusToReceiptStatus(null));
         assertEquals(LEVERT, mapCorrespondenceStatusToReceiptStatus(CorrespondenceStatusExt.PUBLISHED));
         assertEquals(LEST, mapCorrespondenceStatusToReceiptStatus(CorrespondenceStatusExt.READ));
-        assertEquals(null, mapCorrespondenceStatusToReceiptStatus(CorrespondenceStatusExt.READY_FOR_PUBLISH));
+        assertNull(mapCorrespondenceStatusToReceiptStatus(CorrespondenceStatusExt.READY_FOR_PUBLISH));
 
         // all except the following list should be mapped to ANNET
         var mappedStatuses = List.of(

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
@@ -72,7 +72,7 @@ class DpvStatusStrategyTest {
         MessageStatus annetStatus = MessageStatus.of(ANNET, null, null);
         Mockito.when(altinnService.getStatus(conversation))
                 .thenThrow(new CorrespondenceApiException("not found", HttpStatus.valueOf(statusCode)));
-        Mockito.when(messageStatusFactory.getMessageStatus(ANNET)).thenReturn(annetStatus);
+        Mockito.when(messageStatusFactory.getMessageStatus(eq(ANNET), Mockito.anyString())).thenReturn(annetStatus);
 
         dpvStatusStrategy.checkStatus(Set.of(conversation));
 


### PR DESCRIPTION
For DPV kan mottaker av en meldingen kan selv sletter den (status blir PurgedByReceiver).  Dette kan mottaker gjøre uten å ha lest den (sånn at den aldri får status Read).   Problemet er at uten endelig status "Read" så forstetter vi å sjekke status på meldingen.   Status sjekk på meldinger som er slettet gir http 404 NOT_FOUND så har vi hundretusener av statussjekker hver uke som sjekker etter meldinger som aldri kommer til å endre status.   Det samme kan skje dersom mottaker leser og umiddelbart slette meldingen før vi rekker å lese status "Read" fra Altinn.  Eller dersom Altinn rydder og sletter, PurgedByAltinn.

Har verifisert med Altinn at vi kan p.t. kan anta at 404 NOT_FOUND betyr at meldingen er slettet enten av mottaker eller av Altinn.

Vi logge en WARN om at meldingen er slettet og polling derfor skrus av.  Vi setter også status ANNET på meldingen for å registrere at det skjer.