### PR TITLE
MOVE-5112 Skrur av polling for meldinger som rapporteres som slettet / purged

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
@@ -51,8 +51,14 @@ public class AltinnDPVService {
         statusEvents.add(createStatusEvent(CorrespondenceStatusExt.INITIALIZED, overview.getCreated()));
         if (overview.getPublished() != null) statusEvents.add(createStatusEvent(CorrespondenceStatusExt.PUBLISHED, overview.getPublished()));
         if (overview.getRead() != null) statusEvents.add(createStatusEvent(CorrespondenceStatusExt.READ, overview.getRead()));
+        if (isPurged(overview.getStatus())) statusEvents.add(createStatusEvent(overview.getStatus(), overview.getStatusChanged()));
         return statusEvents;
 
+    }
+
+    public static boolean isPurged(CorrespondenceStatusExt status) {
+        return CorrespondenceStatusExt.PURGED_BY_RECIPIENT.equals(status)
+                || CorrespondenceStatusExt.PURGED_BY_ALTINN.equals(status);
     }
 
     private CorrespondenceStatusEventExt createStatusEvent(CorrespondenceStatusExt status, OffsetDateTime timestamp) {

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
@@ -12,6 +12,8 @@ import no.difi.meldingsutveksling.status.Conversation;
 import no.digdir.altinn3.correspondence.model.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -22,7 +24,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -129,6 +133,55 @@ public class AltinnDPVServiceTest {
         assertEquals(CorrespondenceStatusExt.PUBLISHED, history.get(1).getStatus());
         assertEquals(CorrespondenceStatusExt.READ, history.getLast().getStatus());
         assertEquals("2026-06-01T12:12:12Z", history.getLast().getStatusChanged().toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CorrespondenceStatusExt.class, names = {"PURGED_BY_RECIPIENT", "PURGED_BY_ALTINN"})
+    public void getStatusIncludesPurgedStatusFromOverview(CorrespondenceStatusExt purgedStatus) {
+        Conversation conversation = new Conversation();
+        conversation.setConversationId("019eca65-3f08-7007-83df-2cb0f31d4dd7");
+        conversation.setExternalSystemReference("019eca65-3ec9-78e0-ad1d-30c1326c6f31");
+
+        Mockito.when(correspondenceApiClient.getCorrespondenceOverview(Mockito.any())).thenReturn(
+            new CorrespondenceOverviewExt()
+                .created(OffsetDateTime.parse("2026-06-01T10:10:10Z"))
+                .published(OffsetDateTime.parse("2026-06-01T11:11:11Z"))
+                .read(OffsetDateTime.parse("2026-06-01T12:12:12Z"))
+                .status(purgedStatus)
+                .statusChanged(OffsetDateTime.parse("2026-06-01T13:13:13Z"))
+        );
+
+        var history = altinnDPVService.getStatus(conversation);
+
+        assertEquals(purgedStatus, history.getLast().getStatus());
+        assertEquals("2026-06-01T13:13:13Z", history.getLast().getStatusChanged().toString());
+    }
+
+    @Test
+    public void getStatusDoesNotIncludeOverviewStatusWhenNotPurged() {
+        Conversation conversation = new Conversation();
+        conversation.setConversationId("019eca65-3f08-7007-83df-2cb0f31d4dd7");
+        conversation.setExternalSystemReference("019eca65-3ec9-78e0-ad1d-30c1326c6f31");
+
+        Mockito.when(correspondenceApiClient.getCorrespondenceOverview(Mockito.any())).thenReturn(
+            new CorrespondenceOverviewExt()
+                .created(OffsetDateTime.parse("2026-06-01T10:10:10Z"))
+                .published(OffsetDateTime.parse("2026-06-01T11:11:11Z"))
+                .status(CorrespondenceStatusExt.PUBLISHED)
+        );
+
+        var history = altinnDPVService.getStatus(conversation);
+
+        assertEquals(2, history.size());
+        assertEquals(CorrespondenceStatusExt.PUBLISHED, history.getLast().getStatus());
+    }
+
+    @Test
+    public void isPurgedReturnsTrueOnlyForPurgedStatuses() {
+        assertTrue(AltinnDPVService.isPurged(CorrespondenceStatusExt.PURGED_BY_RECIPIENT));
+        assertTrue(AltinnDPVService.isPurged(CorrespondenceStatusExt.PURGED_BY_ALTINN));
+        assertFalse(AltinnDPVService.isPurged(CorrespondenceStatusExt.PUBLISHED));
+        assertFalse(AltinnDPVService.isPurged(null));
     }
 
 }

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategy.java
@@ -106,6 +106,10 @@ public class DpvStatusStrategy implements StatusStrategy {
                 c.getMessageId(), c.getConversationId());
 
         for (CorrespondenceStatusEventExt event : status) {
+            if (AltinnDPVService.isPurged(event.getStatus())) {
+                handlePurged(c, event.getStatus());
+            }
+
             ReceiptStatus mappedStatus = mapCorrespondenceStatusToReceiptStatus(event.getStatus());
             if (mappedStatus == null) {
                 // status was not mapped, we log it as ignored
@@ -130,6 +134,17 @@ public class DpvStatusStrategy implements StatusStrategy {
         }
     }
 
+    private void handlePurged(Conversation c, CorrespondenceStatusExt status) {
+        log.warn(ConversationMarker.markerFrom(c),
+                "Message [id={}, conversationId={}] was purged ({}), stopping polling.",
+                c.getMessageId(), c.getConversationId(), status);
+
+        if (c.isPollable()) {
+            c.setPollable(false);
+            conversationService.save(c);
+        }
+    }
+
     @Nullable
     static ReceiptStatus mapCorrespondenceStatusToReceiptStatus(CorrespondenceStatusExt status) {
         ReceiptStatus mappedStatus;
@@ -141,9 +156,10 @@ public class DpvStatusStrategy implements StatusStrategy {
                 CorrespondenceStatusExt.READY_FOR_PUBLISH.equals(status) ||
                 CorrespondenceStatusExt.INITIALIZED.equals(status) ||
                 CorrespondenceStatusExt.FETCHED.equals(status) ||
-                CorrespondenceStatusExt.ATTACHMENTS_DOWNLOADED.equals(status))
-        {
+                CorrespondenceStatusExt.ATTACHMENTS_DOWNLOADED.equals(status)) {
             mappedStatus = null; // do not map this, just ignore it
+        } else if (AltinnDPVService.isPurged(status)) {
+            mappedStatus = ANNET;
         } else {
             log.info("Unknown correspondence status [{}]", status);
             mappedStatus = ANNET;

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/receipt/strategy/DpvStatusStrategyTest.java
@@ -1,19 +1,23 @@
 package no.difi.meldingsutveksling.receipt.strategy;
 
+import no.difi.meldingsutveksling.ServiceIdentifier;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
 import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
 import no.difi.meldingsutveksling.altinnv3.dpv.InvalidConversationReferenceException;
 import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.NextMoveQueue;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
+import no.difi.meldingsutveksling.nextmove.ConversationDirection;
 import no.difi.meldingsutveksling.sbd.SBDFactory;
 import no.difi.meldingsutveksling.status.Conversation;
 import no.difi.meldingsutveksling.status.MessageStatus;
 import no.difi.meldingsutveksling.status.MessageStatusFactory;
+import no.digdir.altinn3.correspondence.model.CorrespondenceStatusEventExt;
 import no.digdir.altinn3.correspondence.model.CorrespondenceStatusExt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -21,7 +25,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -92,6 +98,30 @@ class DpvStatusStrategyTest {
 
         assertTrue(conversation.isPollable(), "The conversation should still be pollable for non 404/410 errors");
         Mockito.verify(conversationService, Mockito.never()).registerStatus(eq(conversation), Mockito.any(MessageStatus.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CorrespondenceStatusExt.class, names = {"PURGED_BY_RECIPIENT", "PURGED_BY_ALTINN"})
+    void whenPurgedStopPollingAndRegisterAnnet(CorrespondenceStatusExt purgedStatus) {
+        Conversation conversation = new Conversation();
+        conversation.setPollable(true);
+        conversation.setServiceIdentifier(ServiceIdentifier.DPV);
+        conversation.setDirection(ConversationDirection.OUTGOING);
+        conversation.setMessageStatuses(new HashSet<>());
+
+        CorrespondenceStatusEventExt purgedEvent = new CorrespondenceStatusEventExt()
+                .status(purgedStatus)
+                .statusChanged(OffsetDateTime.now());
+
+        MessageStatus annetStatus = MessageStatus.of(ANNET, null, null);
+        Mockito.when(altinnService.getStatus(conversation)).thenReturn(List.of(purgedEvent));
+        Mockito.when(messageStatusFactory.getMessageStatus(ANNET)).thenReturn(annetStatus);
+
+        dpvStatusStrategy.checkStatus(Set.of(conversation));
+
+        assertFalse(conversation.isPollable(), "Polling should stop when the message has been purged");
+        Mockito.verify(conversationService, Mockito.times(1)).save(conversation);
+        Mockito.verify(conversationService, Mockito.times(1)).registerStatus(conversation, annetStatus);
     }
 
     @Test


### PR DESCRIPTION
- PurgedByRecipient og PurgedByAltinn blir logget med warning med hvilken Conversation det gjelder og at vi har stoppet polling av meldingen.
- Failed forblir uendret som i dag (logges allerede)
- Alle statuser gir status ANNET (ingen endringer, samme som i dag)