### PR TITLE
MOVE-5104 Tar i bruk idempotency i correspondence api'et for å unngå duplikater

### DIFF
--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -33,10 +34,25 @@ public class AltinnDPVService {
             null,
             files.stream().map(FileUploadRequest::getBusinessMessageFile).collect(Collectors.toList()));
 
+        // selv om den er String i koden skal den inneholde en UUID (ingen andre steder i kodebasen wrapper
+        // tilsvarende UUID.fromString-kall i try/catch, alle stoler på den samme oppstrøms bean-valideringen)
+        correspondence.setIdempotentKey(UUID.fromString(message.getMessageId()));
+
         var result = client.upload(correspondence, files);
 
         if (result == null || result.getCorrespondences() == null) { throw new CorrespondenceApiException("Error when sending message to Altinn, response was null");}
         return result.getCorrespondences().getFirst().getCorrespondenceId();
+    }
+
+    // brukes til å finne igjen correspondenceId etter en 409-konflikt på upload (idempotentKey allerede kjent
+    // hos Altinn), siden sendersReference alltid settes til messageId ved opplasting, se CorrespondenceFactory
+    public Optional<UUID> findExistingCorrespondenceId(String messageId) {
+        var correspondences = client.findCorrespondences(messageId);
+
+        if (correspondences == null || correspondences.getIds() == null || correspondences.getIds().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(correspondences.getIds().getFirst());
     }
 
     public List<CorrespondenceStatusEventExt> getStatus(Conversation conversation) {

--- a/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
+++ b/altinn-v3-client/src/main/java/no/difi/meldingsutveksling/altinnv3/dpv/CorrespondenceApiClient.java
@@ -107,6 +107,20 @@ public class CorrespondenceApiClient {
             ;
     }
 
+    // brukes til å finne igjen en correspondence etter en 409-konflikt (idempotentKey allerede kjent),
+    // siden sendersReference alltid settes til vår egen messageId ved opplasting
+    public CorrespondencesExt findCorrespondences(String sendersReference) {
+        String accessToken = tokenProducer.produceToken(scopes);
+
+        return restClient.get()
+            .uri(correspondenceServiceUrl + "/correspondence?sendersReference={sendersReference}", sendersReference)
+            .header("Authorization", "Bearer " + accessToken)
+            .header("Accept", "application/json")
+            .retrieve()
+            .body(CorrespondencesExt.class)
+            ;
+    }
+
     public byte[] downloadAttachment(UUID correspondenceId, UUID attachmentId) {
         String accessToken = tokenProducer.produceToken(scopes);
 

--- a/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
+++ b/altinn-v3-client/src/test/java/no/difi/meldingsutveksling/altinnv3/dpv/AltinnDPVServiceTest.java
@@ -23,10 +23,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +58,7 @@ public class AltinnDPVServiceTest {
         response2.setCorrespondences(List.of(response));
 
         NextMoveOutMessage message = new NextMoveOutMessage();
+        message.setMessageId(UUID.randomUUID().toString());
         StandardBusinessDocument sbd = new StandardBusinessDocument()
             .setStandardBusinessDocumentHeader(new StandardBusinessDocumentHeader()
                 .setSenderIdentifier(SENDER)

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImpl.java
@@ -13,9 +13,11 @@ import no.difi.meldingsutveksling.domain.sbdh.SBDUtil;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static no.difi.meldingsutveksling.logging.NextMoveMessageMarkers.markerFrom;
@@ -47,6 +49,12 @@ public class DpvConversationStrategyImpl implements DpvConversationStrategy {
             correspondenceid = WithLogstashMarker.withLogstashMarker(markerFrom(message))
                     .execute(() -> altinnService.send(message));
         } catch (CorrespondenceApiException e) {
+            if (HttpStatus.CONFLICT.equals(e.getStatusCode())) {
+                // Idempotent key allerede kjent hos Altinn - correspondence ble opprettet i et tidligere forsøk
+                // (f.eks. svaret gikk tapt). Behandles som en normal, vellykket sending.
+                handleIdempotentKeyConflict(message, e);
+                return;
+            }
             if (e.getStatusCode() != null && e.getStatusCode().is4xxClientError()) {
                 throw new QueueInterruptException(e.getMessage());
             }
@@ -57,6 +65,43 @@ public class DpvConversationStrategyImpl implements DpvConversationStrategy {
             .ifPresent(conversation -> conversationService.save(conversation
                 .setExternalSystemReference(correspondenceid.toString())));
 
+    }
+
+    private void handleIdempotentKeyConflict(NextMoveOutMessage message, CorrespondenceApiException e) {
+        log.warn(markerFrom(message),
+                "Correspondence for message [{}] in conversation [{}] finnes allerede hos Altinn " +
+                        "(idempotent key konflikt) - antar meldingen ble levert i et tidligere forsøk. " +
+                        "Slår opp correspondenceId via sendersReference. Detaljer: {}",
+                message.getMessageId(), message.getConversationId(), e.getMessage());
+
+        Optional<UUID> correspondenceId;
+        try {
+            correspondenceId = altinnService.findExistingCorrespondenceId(message.getMessageId());
+        } catch (Exception lookupException) {
+            disablePolling(message, "Oppslag på sendersReference feilet: " + lookupException.getMessage());
+            return;
+        }
+
+        if (correspondenceId.isEmpty()) {
+            disablePolling(message, "Fant ingen correspondence hos Altinn ved oppslag på sendersReference.");
+            return;
+        }
+
+        conversationService.findConversation(message.getMessageId())
+                .ifPresent(conversation -> conversationService.save(conversation
+                        .setExternalSystemReference(correspondenceId.get().toString())));
+    }
+
+    private void disablePolling(NextMoveOutMessage message, String reason) {
+        log.error(markerFrom(message),
+                "Klarte ikke å fastslå correspondenceId for message [{}] in conversation [{}] etter idempotent " +
+                        "key konflikt. {} Stopper polling for denne samtalen.",
+                message.getMessageId(), message.getConversationId(), reason);
+
+        conversationService.findConversation(message.getMessageId())
+                .ifPresent(conversation -> conversationService.save(conversation
+                        .setPollable(false)
+                        .setFinished(true)));
     }
 
 }

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/DpvConversationStrategyImplTest.java
@@ -4,6 +4,7 @@ import no.difi.meldingsutveksling.QueueInterruptException;
 import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
 import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
 import no.difi.meldingsutveksling.api.ConversationService;
+import no.difi.meldingsutveksling.status.Conversation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,8 +13,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DpvConversationStrategyImplTest {
@@ -51,6 +54,57 @@ public class DpvConversationStrategyImplTest {
 
         assertEquals(serverError, exception);
         Mockito.verifyNoInteractions(conversationService);
+    }
+
+    @Test
+    public void send_setsExternalSystemReference_whenConflictResolvedViaSendersReferenceLookup() {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        CorrespondenceApiException conflict = new CorrespondenceApiException("Conflict", HttpStatus.CONFLICT);
+        UUID existingCorrespondenceId = UUID.randomUUID();
+        Conversation conversation = new Conversation();
+
+        Mockito.when(altinnService.send(message)).thenThrow(conflict);
+        Mockito.when(altinnService.findExistingCorrespondenceId(message.getMessageId())).thenReturn(Optional.of(existingCorrespondenceId));
+        Mockito.when(conversationService.findConversation(message.getMessageId())).thenReturn(Optional.of(conversation));
+
+        assertDoesNotThrow(() -> target.send(message));
+
+        assertEquals(existingCorrespondenceId.toString(), conversation.getExternalSystemReference());
+        Mockito.verify(conversationService).save(conversation);
+    }
+
+    @Test
+    public void send_disablesPolling_whenSendersReferenceLookupFindsNoCorrespondence() {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        CorrespondenceApiException conflict = new CorrespondenceApiException("Conflict", HttpStatus.CONFLICT);
+        Conversation conversation = new Conversation();
+
+        Mockito.when(altinnService.send(message)).thenThrow(conflict);
+        Mockito.when(altinnService.findExistingCorrespondenceId(message.getMessageId())).thenReturn(Optional.empty());
+        Mockito.when(conversationService.findConversation(message.getMessageId())).thenReturn(Optional.of(conversation));
+
+        assertDoesNotThrow(() -> target.send(message));
+
+        assertFalse(conversation.isPollable());
+        assertTrue(conversation.isFinished());
+        Mockito.verify(conversationService).save(conversation);
+    }
+
+    @Test
+    public void send_disablesPolling_whenSendersReferenceLookupThrows() {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        CorrespondenceApiException conflict = new CorrespondenceApiException("Conflict", HttpStatus.CONFLICT);
+        Conversation conversation = new Conversation();
+
+        Mockito.when(altinnService.send(message)).thenThrow(conflict);
+        Mockito.when(altinnService.findExistingCorrespondenceId(message.getMessageId())).thenThrow(new RuntimeException("lookup boom"));
+        Mockito.when(conversationService.findConversation(message.getMessageId())).thenReturn(Optional.of(conversation));
+
+        assertDoesNotThrow(() -> target.send(message));
+
+        assertFalse(conversation.isPollable());
+        assertTrue(conversation.isFinished());
+        Mockito.verify(conversationService).save(conversation);
     }
 
 }

--- a/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/NextMoveSenderTest.java
+++ b/integrasjonspunkt/src/test/java/no/difi/meldingsutveksling/nextmove/NextMoveSenderTest.java
@@ -1,0 +1,80 @@
+package no.difi.meldingsutveksling.nextmove;
+
+import no.difi.meldingsutveksling.altinnv3.dpv.AltinnDPVService;
+import no.difi.meldingsutveksling.altinnv3.dpv.CorrespondenceApiException;
+import no.difi.meldingsutveksling.api.ConversationService;
+import no.difi.meldingsutveksling.api.MessagePersister;
+import no.difi.meldingsutveksling.domain.sbdh.SBDService;
+import no.difi.meldingsutveksling.nextmove.v2.BusinessMessageFileRepository;
+import no.difi.meldingsutveksling.nextmove.v2.NextMoveMessageOutRepository;
+import no.difi.meldingsutveksling.receipt.ReceiptStatus;
+import no.difi.meldingsutveksling.status.Conversation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NextMoveSenderTest {
+
+    @Mock
+    private ConversationStrategyFactory strategyFactory;
+
+    @Mock
+    private ConversationService conversationService;
+
+    @Mock
+    private NextMoveMessageOutRepository messageRepo;
+
+    @Mock
+    private BusinessMessageFileRepository businessMessageFileRepository;
+
+    @Mock
+    private SBDService sbdService;
+
+    @Mock
+    private TimeToLiveHelper timeToLiveHelper;
+
+    @Mock
+    private MessagePersister messagePersister;
+
+    @Mock
+    private AltinnDPVService altinnDPVService;
+
+    // End-to-end: NextMoveSender -> (ekte) DpvConversationStrategyImpl -> AltinnDPVService (mocket).
+    // Verifiserer at en 409-konflikt fra Altinn på upload, etterfulgt av et vellykket oppslag på
+    // sendersReference, ender med at meldingen får status SENDT akkurat som ved en normal, vellykket sending.
+    @Test
+    public void send_registersSendtStatus_whenDpvUploadConflictsButSendersReferenceLookupSucceeds() throws Exception {
+        NextMoveOutMessage message = StandardBusinessDocumentTestData.DIGITAL_DPV_MESSAGE;
+        UUID existingCorrespondenceId = UUID.randomUUID();
+        Conversation conversation = new Conversation();
+
+        DpvConversationStrategyImpl dpvStrategy = new DpvConversationStrategyImpl(conversationService, altinnDPVService);
+
+        when(sbdService.isExpired(message.getSbd())).thenReturn(false);
+        when(strategyFactory.getStrategy(message.getServiceIdentifier())).thenReturn(Optional.of(dpvStrategy));
+        when(altinnDPVService.send(message)).thenThrow(new CorrespondenceApiException("Conflict", HttpStatus.CONFLICT));
+        when(altinnDPVService.findExistingCorrespondenceId(message.getMessageId())).thenReturn(Optional.of(existingCorrespondenceId));
+        when(conversationService.findConversation(message.getMessageId())).thenReturn(Optional.of(conversation));
+        when(messageRepo.findIdByMessageId(message.getMessageId())).thenReturn(Optional.empty());
+
+        NextMoveSender sender = new NextMoveSender(strategyFactory, conversationService, messageRepo,
+                businessMessageFileRepository, sbdService, timeToLiveHelper, messagePersister);
+
+        sender.send(message);
+
+        assertEquals(existingCorrespondenceId.toString(), conversation.getExternalSystemReference());
+        verify(conversationService).registerStatus(message.getMessageId(), ReceiptStatus.SENDT);
+        verify(messagePersister).delete(message.getMessageId());
+    }
+
+}

--- a/integrasjonspunkt/src/test/resources/cucumber/nextmove_send_digital_dpv.feature
+++ b/integrasjonspunkt/src/test/resources/cucumber/nextmove_send_digital_dpv.feature
@@ -110,7 +110,8 @@ Feature: Sending a Next Move Digital DPV message
         "correspondence.notification.reminderEmailSubject" : "Melding mottatt i Altinn",
         "correspondence.resourceId": "eformidling-dpv-administrasjon",
         "correspondence.propertyList.senderOrgNumber": "910077473",
-        "correspondence.ignoreReservation": "true"
+        "correspondence.ignoreReservation": "true",
+        "idempotentKey" : "ff88849c-e281-4809-8555-7cd54952b922"
 
     }
     """

--- a/integrasjonspunkt/src/test/resources/cucumber/nextmove_send_dpv.feature
+++ b/integrasjonspunkt/src/test/resources/cucumber/nextmove_send_dpv.feature
@@ -192,7 +192,8 @@ Feature: Sending a Next Move DPV message
         "correspondence.notification.reminderEmailSubject" : "Melding mottatt i Altinn",
         "correspondence.resourceId": "eformidling-dpv-administrasjon",
         "correspondence.propertyList.senderOrgNumber": "910077473",
-        "correspondence.ignoreReservation": "false"
+        "correspondence.ignoreReservation": "false",
+        "idempotentKey" : "abc8849c-e281-4809-8555-7cd54952b926"
     }
     """
     And the sent message contains the following files:


### PR DESCRIPTION
Både IdemportentKey og SendersReference settes lik MessageId, dermed vil en melding som allerede er sendt hvor vi ikke fikk registrert opprinnelig response (pga nettverk/5xx, lb eller proxy error f.eks.) kunne oppdateres ved en resending når vi mottar en http 409 conflict :

- Meldingen fikk ikke satt ExternalSystemReference (som skulle vært satt lik CorrespondenceId når sending ble sendt)
- Men vi kan søke opp den tidligere sendte meldingen via SendersReference ved retry når vi mottar 409.
  - Dersom søket finner tidligere melding henter vi CorrespondenceId og oppdaterer den i basen (da vil polling fungere som normalt etterpå)
  - Dersom vi ikke fant tidligere melding logger vi det som en feil og skrur av polling (vi kan ikke polle meldinger vi mangler CorrespondenceId for)
- Uansett vil meldingen få status `SENDT`